### PR TITLE
feature/234-improve-favicons

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -17,7 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
+        with:
+          fetch-depth: 0
       - uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.run/BaywatchApplication.run.xml
+++ b/.run/BaywatchApplication.run.xml
@@ -8,7 +8,7 @@
       <env name="BAYWATCH_IMGPROXY_SALT" value="c20a3becb08164a79bffa4" />
       <env name="BAYWATCH_IMGPROXY_SIGNKEY" value="ad27d1a476e2d0f6326c76f275ed" />
       <env name="BAYWATCH_INDEXER_ENABLE" value="true" />
-      <env name="BAYWATCH_SCRAPER_ENABLE" value="false" />
+      <env name="BAYWATCH_SCRAPER_ENABLE" value="true" />
       <env name="CONSOLE_LOG_PATTERN" value="%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd'T'HH:mm:ss.SSSXXX}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(---){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}" />
       <env name="SPRING_THREADS_VIRTUAL_ENABLED" value="true" />
     </envs>

--- a/.run/BaywatchApplication.run.xml
+++ b/.run/BaywatchApplication.run.xml
@@ -5,6 +5,8 @@
       <env name="BAYWATCH_GRAPHQL_INTROSPECTION" value="true" />
       <env name="BAYWATCH_HOME" value="$USER_HOME$" />
       <env name="BAYWATCH_IMGPROXY_ENABLE" value="false" />
+      <env name="BAYWATCH_IMGPROXY_SALT" value="c20a3becb08164a79bffa4" />
+      <env name="BAYWATCH_IMGPROXY_SIGNKEY" value="ad27d1a476e2d0f6326c76f275ed" />
       <env name="BAYWATCH_INDEXER_ENABLE" value="true" />
       <env name="BAYWATCH_SCRAPER_ENABLE" value="false" />
       <env name="CONSOLE_LOG_PATTERN" value="%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd'T'HH:mm:ss.SSSXXX}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(---){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}" />

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       IMGPROXY_PRESETS: |
         desktop=resize:fill:240:238/ex:1/gravity:ce,
         mobile=resize:fill:268:96/ex:1/gravity:sm,
-        icon=resize:fill:32:32/ex:1/gravity:sm
+        icon=resize:fit:32:32
       IMGPROXY_SALT: "c20a3becb08164a79bffa4"
     ports:
       - "8082:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: "3.9"
 
 volumes:
   prometheus_data: {}
@@ -37,6 +36,39 @@ services:
     volumes:
       - /home/marthym:/var/lib/baywatch
       - /tmp/baywatch:/tmp
+
+  imgproxy:
+    image: ghcr.io/imgproxy/imgproxy:v3.27.2
+    restart: unless-stopped
+    read_only: true
+    labels:
+      application: imgproxy
+    logging:
+      driver: json-file
+      options:
+        labels: 'application'
+        tag: '{{ "id={{.ID}} name={{.Name}} image={{.ImageName}}" }}'
+        max-size: '12m'
+        max-file: '5'
+    environment:
+      IMGPROXY_ALLOW_ORIGIN: "*"
+      IMGPROXY_COOKIE_PASSTHROUGH: true
+      IMGPROXY_AUTO_AVIF: true
+      IMGPROXY_ENFORCE_AVIF: true
+      IMGPROXY_KEY: "ad27d1a476e2d0f6326c76f275ed"
+      IMGPROXY_LOG_FORMAT: pretty
+      IMGPROXY_LOG_LEVEL: debug
+      IMGPROXY_MAX_SRC_RESOLUTION: 20.5
+      IMGPROXY_PATH_PREFIX: "/img"
+      IMGPROXY_PRESETS: |
+        desktop=resize:fill:240:238/ex:1/gravity:ce,
+        mobile=resize:fill:268:96/ex:1/gravity:sm,
+        icon=resize:fill:32:32/ex:1/gravity:sm
+      IMGPROXY_SALT: "c20a3becb08164a79bffa4"
+    ports:
+      - "8082:8080"
+    networks:
+      - bwnet
 
   prometheus:
     image: prom/prometheus:v2.43.0

--- a/pom.xml
+++ b/pom.xml
@@ -43,10 +43,11 @@
         <nbvcxz.version>1.5.1</nbvcxz.version>
         <nimbus-jose-jwt.version>10.0.1</nimbus-jose-jwt.version>
         <noexception.version>1.9.1</noexception.version>
-        <scraphead.version>1.4.1</scraphead.version>
+        <scraphead.version>1.4.2-SNAPSHOT</scraphead.version>
         <testy-box.version>1.7.2</testy-box.version>
         <ulid-creator.version>5.2.3</ulid-creator.version>
         <unbescape.version>1.1.6.RELEASE</unbescape.version>
+        <lombok.version>1.18.36</lombok.version>
 
         <exec-maven-plugin.version>3.5.0</exec-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <nbvcxz.version>1.5.1</nbvcxz.version>
         <nimbus-jose-jwt.version>10.0.1</nimbus-jose-jwt.version>
         <noexception.version>1.9.1</noexception.version>
-        <scraphead.version>1.4.2-SNAPSHOT</scraphead.version>
+        <scraphead.version>1.4.2</scraphead.version>
         <testy-box.version>1.7.2</testy-box.version>
         <ulid-creator.version>5.2.3</ulid-creator.version>
         <unbescape.version>1.1.6.RELEASE</unbescape.version>

--- a/sandside/pom.xml
+++ b/sandside/pom.xml
@@ -166,6 +166,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/opml/domain/OpmlServiceImpl.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/opml/domain/OpmlServiceImpl.java
@@ -7,7 +7,7 @@ import fr.ght1pc9kc.baywatch.security.api.AuthenticationFacade;
 import fr.ght1pc9kc.baywatch.security.api.model.User;
 import fr.ght1pc9kc.baywatch.security.domain.exceptions.UnauthenticatedUser;
 import fr.ght1pc9kc.baywatch.techwatch.api.model.WebFeed;
-import fr.ght1pc9kc.baywatch.techwatch.infra.persistence.FeedRepository;
+import fr.ght1pc9kc.baywatch.techwatch.infra.adapters.persistence.FeedRepository;
 import fr.ght1pc9kc.entity.api.Entity;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/opml/infra/OpmlServiceAdapter.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/opml/infra/OpmlServiceAdapter.java
@@ -5,7 +5,7 @@ import fr.ght1pc9kc.baywatch.opml.domain.OpmlReader;
 import fr.ght1pc9kc.baywatch.opml.domain.OpmlServiceImpl;
 import fr.ght1pc9kc.baywatch.opml.domain.OpmlWriter;
 import fr.ght1pc9kc.baywatch.security.api.AuthenticationFacade;
-import fr.ght1pc9kc.baywatch.techwatch.infra.persistence.FeedRepository;
+import fr.ght1pc9kc.baywatch.techwatch.infra.adapters.persistence.FeedRepository;
 import lombok.experimental.Delegate;
 import org.springframework.stereotype.Service;
 

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/scraper/api/model/AtomFeed.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/scraper/api/model/AtomFeed.java
@@ -15,6 +15,7 @@ import java.time.Instant;
  * @param author      Names one author of the feed.
  * @param link        Identifies a related Web page. The type of relation is defined by the rel attribute.
  *                    A feed is limited to one alternate per type and hreflang.
+ * @param icon        The URL of the favicon of the server
  * @param updated     Indicates the last time the feed was modified in a significant way.
  */
 @Builder(toBuilder = true)
@@ -24,6 +25,7 @@ public record AtomFeed(
         @Nullable String description,
         @Nullable String author,
         @Nullable URI link,
+        @Nullable URI icon,
         @Nullable Instant updated
 ) {
     public static AtomFeed of(String id, URI link) {

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/scraper/domain/AtomFeedReducer.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/scraper/domain/AtomFeedReducer.java
@@ -32,6 +32,9 @@ public class AtomFeedReducer {
         if (rightSelf.link() != null) {
             atomFeedBuilder.link(rightSelf.link());
         }
+        if (rightSelf.icon() != null) {
+            atomFeedBuilder.icon(rightSelf.icon());
+        }
         if (rightSelf.updated() != null) {
             atomFeedBuilder.updated(rightSelf.updated());
         }

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/scraper/domain/RssAtomParserImpl.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/scraper/domain/RssAtomParserImpl.java
@@ -55,6 +55,7 @@ public final class RssAtomParserImpl implements RssAtomParser {
     private static final String ITEM = "item";
     private static final String LAST_BUILD_DATE = "lastBuildDate";
     private static final String LINK = "link";
+    private static final String ICON = "icon";
     private static final String MANAGING_EDITOR = "managingEditor";
     private static final String NAME = "name";
     private static final String PUB_DATE = "pubDate";
@@ -104,6 +105,7 @@ public final class RssAtomParserImpl implements RssAtomParser {
         String description = null;
         String author = null;
         URI link = null;
+        URI icon = null;
         Instant updated = null;
 
         int deepLevel = -1;
@@ -124,6 +126,7 @@ public final class RssAtomParserImpl implements RssAtomParser {
                             description = tmpDescr;
                     }
                     case LINK -> link = onFeedLink(link, deepLevel, events, idx);
+                    case ICON -> icon = onFeedLink(link, deepLevel, events, idx);
                     case NAME, MANAGING_EDITOR -> author = Optional.ofNullable(author)
                             .map(a -> readElementText(events, idx) + " " + a)
                             .orElse(readElementText(events, idx));
@@ -148,7 +151,7 @@ public final class RssAtomParserImpl implements RssAtomParser {
             updated = clock.instant();
         }
         return new AtomFeed(Optional.ofNullable(link).map(Hasher::identify).orElse(null),
-                title, description, author, link, updated);
+                title, description, author, link, icon, updated);
     }
 
     private static URI onFeedLink(URI old, int deepLevel, List<XMLEvent> events, int idx) {

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/scraper/domain/filters/FaviconFeedFilter.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/scraper/domain/filters/FaviconFeedFilter.java
@@ -1,0 +1,46 @@
+package fr.ght1pc9kc.baywatch.scraper.domain.filters;
+
+import fr.ght1pc9kc.baywatch.scraper.api.model.AtomFeed;
+import fr.ght1pc9kc.baywatch.scraper.domain.model.FeedsFilter;
+import fr.ght1pc9kc.baywatch.scraper.domain.ports.LinkCheckPort;
+import fr.ght1pc9kc.scraphead.core.HeadScraper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
+@Slf4j
+@RequiredArgsConstructor
+public class FaviconFeedFilter implements FeedsFilter {
+    private final HeadScraper headScraper;
+    private final LinkCheckPort linkCheckPort;
+
+    @Override
+    public Mono<AtomFeed> filter(@NotNull AtomFeed feed) {
+        if (isNull(feed.link())) {
+            return Mono.just(feed);
+        }
+        URI favicon = URI.create(String.format("%s://%s/favicon.ico",
+                feed.link().getScheme(), feed.link().getAuthority()));
+        return headScraper.scrap(URI.create(
+                        String.format("%s://%s/", feed.link().getScheme(), feed.link().getAuthority())))
+                .filter(metas -> nonNull(metas.links().icon()))
+                .map(metas -> metas.links().icon())
+                .onErrorResume(ignore -> Mono.empty())
+                .switchIfEmpty(linkCheckPort.check(favicon))
+                .map(icon -> feed.toBuilder()
+                        .icon(icon)
+                        .build())
+                .onErrorResume(t -> {
+                    log.atInfo().addArgument(t.getClass()).addArgument(t.getLocalizedMessage())
+                            .log("{}: {}");
+                    log.atDebug().log("STACKTRACE", t);
+                    return Mono.just(feed);
+                });
+    }
+}

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/scraper/domain/filters/ImageLinkValidationFilter.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/scraper/domain/filters/ImageLinkValidationFilter.java
@@ -1,26 +1,23 @@
 package fr.ght1pc9kc.baywatch.scraper.domain.filters;
 
 import fr.ght1pc9kc.baywatch.scraper.api.NewsFilter;
+import fr.ght1pc9kc.baywatch.scraper.domain.ports.LinkCheckPort;
 import fr.ght1pc9kc.baywatch.techwatch.api.model.RawNews;
 import fr.ght1pc9kc.scraphead.core.scrap.OGScrapperUtils;
-import io.netty.handler.codec.http.HttpHeaderNames;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.reactive.function.client.ClientResponse;
-import org.springframework.web.reactive.function.client.WebClient;
 import org.unbescape.html.HtmlEscape;
 import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 
 @Slf4j
 @RequiredArgsConstructor
 public class ImageLinkValidationFilter implements NewsFilter {
     private static final Set<String> SUPPORTED_SCHEMES = Set.of("http", "https");
-    private final WebClient http;
+    private final LinkCheckPort linkCheckPort;
 
     @Override
     public Mono<RawNews> filter(RawNews news) {
@@ -31,30 +28,11 @@ public class ImageLinkValidationFilter implements NewsFilter {
         URI tested = (news.image().getQuery() == null) ? news.image() :
                 URI.create(OGScrapperUtils.removeQueryString(news.image().toString())
                         + "?" + HtmlEscape.unescapeHtml(news.image().getQuery()));
-        return http.get().uri(tested).exchangeToMono(ClientResponse::toBodilessEntity)
-                .map(response -> {
-                    if (response.getStatusCode().is2xxSuccessful()) {
-                        log.trace("SUCCESS  {}", tested);
-                        if (tested.equals(news.image()))
-                            return news;
-                        else
-                            return news.withImage(tested);
 
-                    } else if (response.getStatusCode().is3xxRedirection()) {
-                        URI location = Optional.ofNullable(
-                                        response.getHeaders().get(HttpHeaderNames.LOCATION.toString()))
-                                .map(l -> l.get(0))
-                                .map(URI::create)
-                                .orElse(tested);
-                        log.trace("REDIRECT {}", location);
-                        log.trace("    FROM {}", tested);
-                        return news.withImage(location);
-
-                    } else {
-                        log.debug("BAD     {}", tested);
-                        return news.withImage(null);
-                    }
-                }).onErrorResume(e -> {
+        return linkCheckPort.check(tested)
+                .map(news::withImage)
+                .switchIfEmpty(Mono.just(news.withImage(null)))
+                .onErrorResume(e -> {
                     log.info("Error on validate link {}", tested);
                     log.debug("{}: {}", e.getClass(), e.getLocalizedMessage());
                     return Mono.just(news.withImage(null));

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/scraper/domain/ports/LinkCheckPort.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/scraper/domain/ports/LinkCheckPort.java
@@ -1,0 +1,9 @@
+package fr.ght1pc9kc.baywatch.scraper.domain.ports;
+
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+
+public interface LinkCheckPort {
+    Mono<URI> check(URI link);
+}

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/scraper/infra/adapters/LinkCheckAdapter.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/scraper/infra/adapters/LinkCheckAdapter.java
@@ -1,0 +1,46 @@
+package fr.ght1pc9kc.baywatch.scraper.infra.adapters;
+
+import fr.ght1pc9kc.baywatch.scraper.domain.ports.LinkCheckPort;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LinkCheckAdapter implements LinkCheckPort {
+    private final WebClient http;
+
+    @Override
+    public Mono<URI> check(URI link) {
+        return http.get().uri(link).exchangeToMono(ClientResponse::toBodilessEntity)
+                .flatMap(response -> {
+                    if (response.getStatusCode().is2xxSuccessful()) {
+                        log.trace(" SUCCESS {}", link);
+                        return Mono.just(link);
+
+                    } else if (response.getStatusCode().is3xxRedirection()) {
+                        URI location = Optional.ofNullable(
+                                        response.getHeaders().get(HttpHeaderNames.LOCATION.toString()))
+                                .map(List::getFirst)
+                                .map(URI::create)
+                                .orElse(link);
+                        log.trace("REDIRECT {}", location);
+                        log.trace("    FROM {}", link);
+                        return Mono.just(location);
+
+                    } else {
+                        log.debug("    BAD {}", link);
+                        return Mono.empty();
+                    }
+                });
+    }
+}

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/scraper/infra/config/ScraperConfiguration.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/scraper/infra/config/ScraperConfiguration.java
@@ -1,9 +1,12 @@
 package fr.ght1pc9kc.baywatch.scraper.infra.config;
 
 import fr.ght1pc9kc.baywatch.scraper.api.NewsFilter;
+import fr.ght1pc9kc.baywatch.scraper.domain.filters.FaviconFeedFilter;
 import fr.ght1pc9kc.baywatch.scraper.domain.filters.OpenGraphFilter;
 import fr.ght1pc9kc.baywatch.scraper.domain.filters.RedditNewsFilter;
 import fr.ght1pc9kc.baywatch.scraper.domain.filters.SanitizerFilter;
+import fr.ght1pc9kc.baywatch.scraper.domain.model.FeedsFilter;
+import fr.ght1pc9kc.baywatch.scraper.domain.ports.LinkCheckPort;
 import fr.ght1pc9kc.scraphead.core.HeadScraper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -37,5 +40,11 @@ public class ScraperConfiguration {
     @Order(4)
     public NewsFilter newsSanitizer() {
         return new SanitizerFilter();
+    }
+
+    @Bean
+    @Order(5)
+    public FeedsFilter faviconFeedsFilter(LinkCheckPort linkCheckAdapter, HeadScraper headScraper) {
+        return new FaviconFeedFilter(headScraper, linkCheckAdapter);
     }
 }

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/api/model/ImagePresets.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/api/model/ImagePresets.java
@@ -1,5 +1,5 @@
 package fr.ght1pc9kc.baywatch.techwatch.api.model;
 
 public enum ImagePresets {
-    DESKTOP, MOBILE
+    DESKTOP, ICON, MOBILE
 }

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/api/model/WebFeed.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/api/model/WebFeed.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.NonNull;
 import lombok.Singular;
 import lombok.With;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.net.URI;
@@ -22,6 +23,7 @@ public record WebFeed(
         @With String name,
         @With String description,
         @NonNull URI location,
+        @Nullable URI icon,
         @NonNull @Unmodifiable @Singular Set<String> tags
 ) {
 }

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/domain/FeedServiceImpl.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/domain/FeedServiceImpl.java
@@ -54,7 +54,7 @@ public class FeedServiceImpl implements FeedService {
         this.propertiesVisitor = propertiesVisitor;
         this.proxyficator = (nonNull(imageProxyService))
                 ? original -> original.convert(
-                we -> we.toBuilder().icon(imageProxyService.proxify(we.icon(), ImagePresets.MOBILE)).build())
+                we -> we.toBuilder().icon(imageProxyService.proxify(we.icon(), ImagePresets.ICON)).build())
                 : UnaryOperator.identity();
     }
 

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/domain/FeedServiceImpl.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/domain/FeedServiceImpl.java
@@ -5,6 +5,8 @@ import fr.ght1pc9kc.baywatch.common.domain.QueryContext;
 import fr.ght1pc9kc.baywatch.security.api.AuthenticationFacade;
 import fr.ght1pc9kc.baywatch.security.domain.exceptions.UnauthenticatedUser;
 import fr.ght1pc9kc.baywatch.techwatch.api.FeedService;
+import fr.ght1pc9kc.baywatch.techwatch.api.ImageProxyService;
+import fr.ght1pc9kc.baywatch.techwatch.api.model.ImagePresets;
 import fr.ght1pc9kc.baywatch.techwatch.api.model.WebFeed;
 import fr.ght1pc9kc.baywatch.techwatch.domain.ports.FeedPersistencePort;
 import fr.ght1pc9kc.baywatch.techwatch.domain.ports.ScraperServicePort;
@@ -13,7 +15,7 @@ import fr.ght1pc9kc.entity.api.Entity;
 import fr.ght1pc9kc.juery.api.Criteria;
 import fr.ght1pc9kc.juery.api.PageRequest;
 import fr.ght1pc9kc.juery.api.filter.CriteriaVisitor;
-import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuples;
@@ -24,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import static fr.ght1pc9kc.baywatch.common.api.DefaultMeta.NO_ONE;
 import static fr.ght1pc9kc.baywatch.common.api.exceptions.UnauthorizedException.AUTHENTICATION_NOT_FOUND;
@@ -32,7 +35,6 @@ import static fr.ght1pc9kc.baywatch.common.api.model.FeedMeta.createdBy;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
-@RequiredArgsConstructor
 public class FeedServiceImpl implements FeedService {
     private static final Set<String> ALLOWED_PROTOCOL = Set.of("http", "https");
 
@@ -41,6 +43,20 @@ public class FeedServiceImpl implements FeedService {
     private final ScraperServicePort scraperService;
     private final AuthenticationFacade authFacade;
     private final CriteriaVisitor<List<String>> propertiesVisitor;
+    private final UnaryOperator<Entity<WebFeed>> proxyficator;
+
+    public FeedServiceImpl(
+            FeedPersistencePort feedRepository, ScraperServicePort scraperService, AuthenticationFacade authFacade,
+            CriteriaVisitor<List<String>> propertiesVisitor, @Nullable ImageProxyService imageProxyService) {
+        this.feedRepository = feedRepository;
+        this.scraperService = scraperService;
+        this.authFacade = authFacade;
+        this.propertiesVisitor = propertiesVisitor;
+        this.proxyficator = (nonNull(imageProxyService))
+                ? original -> original.convert(
+                we -> we.toBuilder().icon(imageProxyService.proxify(we.icon(), ImagePresets.MOBILE)).build())
+                : UnaryOperator.identity();
+    }
 
     @Override
     public Mono<Entity<WebFeed>> get(String id) {
@@ -86,7 +102,9 @@ public class FeedServiceImpl implements FeedService {
                             .map(eProps -> Map.entry(eProps.id(), eProps.self()))
                             .collectMap(Map.Entry::getKey, Map.Entry::getValue)
                             .flatMapMany(allProps -> overrideCustomizedFeedProperties(allProps, rawWebFeeds));
-                });
+                })
+                .map(proxyficator)
+                ;
     }
 
     private Flux<Entity<WebFeed>> overrideCustomizedFeedProperties(
@@ -183,6 +201,10 @@ public class FeedServiceImpl implements FeedService {
             feedBuilder.description(feed.description());
             isSame = false;
         }
+        if (nonNull(feed.icon()) && !feed.icon().equals(rawFeed.self().icon())) {
+            feedBuilder.icon(feed.icon());
+            isSame = false;
+        }
         if (!feed.tags().equals(rawFeed.self().tags())) {
             feedBuilder.tags(feed.tags());
             isSame = false;
@@ -209,6 +231,7 @@ public class FeedServiceImpl implements FeedService {
                     WebFeed newf = t.getT2();
                     return oldf.convert(e -> e.toBuilder()
                             .description(newf.description())
+                            .icon(newf.icon())
                             .build());
                 }).collectList();
     }

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/domain/PopularNewsServiceImpl.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/domain/PopularNewsServiceImpl.java
@@ -6,7 +6,7 @@ import fr.ght1pc9kc.baywatch.techwatch.api.PopularNewsService;
 import fr.ght1pc9kc.baywatch.techwatch.api.model.Popularity;
 import fr.ght1pc9kc.baywatch.common.domain.QueryContext;
 import fr.ght1pc9kc.baywatch.techwatch.domain.ports.TeamServicePort;
-import fr.ght1pc9kc.baywatch.techwatch.infra.persistence.StateRepository;
+import fr.ght1pc9kc.baywatch.techwatch.infra.adapters.persistence.StateRepository;
 import fr.ght1pc9kc.entity.api.Entity;
 import fr.ght1pc9kc.juery.api.Criteria;
 import fr.ght1pc9kc.juery.api.Pagination;

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/FeedsCounterProvider.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/FeedsCounterProvider.java
@@ -5,7 +5,7 @@ import fr.ght1pc9kc.baywatch.admin.api.model.CounterGroup;
 import fr.ght1pc9kc.baywatch.admin.api.model.CounterProvider;
 import fr.ght1pc9kc.baywatch.common.api.model.HeroIcons;
 import fr.ght1pc9kc.baywatch.common.domain.QueryContext;
-import fr.ght1pc9kc.baywatch.techwatch.infra.persistence.FeedRepository;
+import fr.ght1pc9kc.baywatch.techwatch.infra.adapters.persistence.FeedRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/NewsCounterProvider.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/NewsCounterProvider.java
@@ -6,7 +6,7 @@ import fr.ght1pc9kc.baywatch.admin.api.model.CounterProvider;
 import fr.ght1pc9kc.baywatch.common.api.model.HeroIcons;
 import fr.ght1pc9kc.baywatch.techwatch.api.model.News;
 import fr.ght1pc9kc.baywatch.common.domain.QueryContext;
-import fr.ght1pc9kc.baywatch.techwatch.infra.persistence.NewsRepository;
+import fr.ght1pc9kc.baywatch.techwatch.infra.adapters.persistence.NewsRepository;
 import fr.ght1pc9kc.juery.api.Pagination;
 import fr.ght1pc9kc.juery.api.pagination.Direction;
 import fr.ght1pc9kc.juery.api.pagination.Sort;

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/PopularNewsServiceAdapter.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/PopularNewsServiceAdapter.java
@@ -4,7 +4,7 @@ import fr.ght1pc9kc.baywatch.security.api.AuthenticationFacade;
 import fr.ght1pc9kc.baywatch.techwatch.api.PopularNewsService;
 import fr.ght1pc9kc.baywatch.techwatch.domain.PopularNewsServiceImpl;
 import fr.ght1pc9kc.baywatch.techwatch.domain.ports.TeamServicePort;
-import fr.ght1pc9kc.baywatch.techwatch.infra.persistence.StateRepository;
+import fr.ght1pc9kc.baywatch.techwatch.infra.adapters.persistence.StateRepository;
 import lombok.experimental.Delegate;
 import org.springframework.stereotype.Service;
 

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/TechwatchMetricsAdapter.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/TechwatchMetricsAdapter.java
@@ -2,8 +2,8 @@ package fr.ght1pc9kc.baywatch.techwatch.infra.adapters;
 
 import fr.ght1pc9kc.baywatch.common.domain.QueryContext;
 import fr.ght1pc9kc.baywatch.security.api.AuthenticationFacade;
-import fr.ght1pc9kc.baywatch.techwatch.infra.persistence.FeedRepository;
-import fr.ght1pc9kc.baywatch.techwatch.infra.persistence.NewsRepository;
+import fr.ght1pc9kc.baywatch.techwatch.infra.adapters.persistence.FeedRepository;
+import fr.ght1pc9kc.baywatch.techwatch.infra.adapters.persistence.NewsRepository;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/persistence/FeedConditionsVisitors.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/persistence/FeedConditionsVisitors.java
@@ -1,4 +1,4 @@
-package fr.ght1pc9kc.baywatch.techwatch.infra.persistence;
+package fr.ght1pc9kc.baywatch.techwatch.infra.adapters.persistence;
 
 import fr.ght1pc9kc.baywatch.common.api.model.EntitiesProperties;
 import fr.ght1pc9kc.baywatch.dsl.Tables;

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/persistence/FeedRepository.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/persistence/FeedRepository.java
@@ -1,4 +1,4 @@
-package fr.ght1pc9kc.baywatch.techwatch.infra.persistence;
+package fr.ght1pc9kc.baywatch.techwatch.infra.adapters.persistence;
 
 import fr.ght1pc9kc.baywatch.common.domain.QueryContext;
 import fr.ght1pc9kc.baywatch.common.infra.DatabaseQualifier;

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/persistence/NewsRepository.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/persistence/NewsRepository.java
@@ -1,4 +1,4 @@
-package fr.ght1pc9kc.baywatch.techwatch.infra.persistence;
+package fr.ght1pc9kc.baywatch.techwatch.infra.adapters.persistence;
 
 import com.machinezoo.noexception.Exceptions;
 import fr.ght1pc9kc.baywatch.common.api.model.EntitiesProperties;

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/persistence/StateRepository.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/persistence/StateRepository.java
@@ -1,4 +1,4 @@
-package fr.ght1pc9kc.baywatch.techwatch.infra.persistence;
+package fr.ght1pc9kc.baywatch.techwatch.infra.adapters.persistence;
 
 import fr.ght1pc9kc.baywatch.common.api.DefaultMeta;
 import fr.ght1pc9kc.baywatch.common.domain.QueryContext;

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/services/FeedServiceAdapter.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/services/FeedServiceAdapter.java
@@ -2,11 +2,13 @@ package fr.ght1pc9kc.baywatch.techwatch.infra.adapters.services;
 
 import fr.ght1pc9kc.baywatch.security.api.AuthenticationFacade;
 import fr.ght1pc9kc.baywatch.techwatch.api.FeedService;
+import fr.ght1pc9kc.baywatch.techwatch.api.ImageProxyService;
 import fr.ght1pc9kc.baywatch.techwatch.domain.FeedServiceImpl;
 import fr.ght1pc9kc.baywatch.techwatch.domain.ports.FeedPersistencePort;
 import fr.ght1pc9kc.baywatch.techwatch.domain.ports.ScraperServicePort;
 import fr.ght1pc9kc.juery.api.filter.CriteriaVisitor;
 import lombok.experimental.Delegate;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -18,7 +20,7 @@ public class FeedServiceAdapter implements FeedService {
     private final FeedService delegate;
 
     public FeedServiceAdapter(FeedPersistencePort feedRepository, ScraperServicePort scraperServicePort, AuthenticationFacade authFacade,
-                              CriteriaVisitor<List<String>> propertiesVisitor) {
-        this.delegate = new FeedServiceImpl(feedRepository, scraperServicePort, authFacade, propertiesVisitor);
+                              CriteriaVisitor<List<String>> propertiesVisitor, @Nullable ImageProxyService imageProxyService) {
+        this.delegate = new FeedServiceImpl(feedRepository, scraperServicePort, authFacade, propertiesVisitor, imageProxyService);
     }
 }

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/services/FeedServiceAdapter.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/services/FeedServiceAdapter.java
@@ -1,4 +1,4 @@
-package fr.ght1pc9kc.baywatch.techwatch.infra.adapters;
+package fr.ght1pc9kc.baywatch.techwatch.infra.adapters.services;
 
 import fr.ght1pc9kc.baywatch.security.api.AuthenticationFacade;
 import fr.ght1pc9kc.baywatch.techwatch.api.FeedService;

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/services/NewsServiceAdapter.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/services/NewsServiceAdapter.java
@@ -1,4 +1,4 @@
-package fr.ght1pc9kc.baywatch.techwatch.infra.adapters;
+package fr.ght1pc9kc.baywatch.techwatch.infra.adapters.services;
 
 import fr.ght1pc9kc.baywatch.security.api.AuthenticationFacade;
 import fr.ght1pc9kc.baywatch.techwatch.api.NewsService;

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/services/ScraperServiceAdapter.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/services/ScraperServiceAdapter.java
@@ -1,4 +1,4 @@
-package fr.ght1pc9kc.baywatch.techwatch.infra.adapters;
+package fr.ght1pc9kc.baywatch.techwatch.infra.adapters.services;
 
 import fr.ght1pc9kc.baywatch.scraper.api.FeedScraperService;
 import fr.ght1pc9kc.baywatch.techwatch.api.model.WebFeed;

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/services/TeamServiceAdapter.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/services/TeamServiceAdapter.java
@@ -1,4 +1,4 @@
-package fr.ght1pc9kc.baywatch.techwatch.infra.adapters;
+package fr.ght1pc9kc.baywatch.techwatch.infra.adapters.services;
 
 import fr.ght1pc9kc.baywatch.teams.api.TeamsService;
 import fr.ght1pc9kc.baywatch.teams.domain.model.PendingFor;

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/config/TechwatchMapper.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/config/TechwatchMapper.java
@@ -16,6 +16,7 @@ import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.HexFormat;
+import java.util.Optional;
 import java.util.Set;
 
 import static fr.ght1pc9kc.baywatch.common.api.model.FeedMeta.ETag;
@@ -23,6 +24,7 @@ import static fr.ght1pc9kc.baywatch.common.api.model.FeedMeta.createdBy;
 import static fr.ght1pc9kc.baywatch.common.api.model.FeedMeta.updated;
 import static fr.ght1pc9kc.baywatch.dsl.tables.Feeds.FEEDS;
 import static fr.ght1pc9kc.baywatch.dsl.tables.FeedsUsers.FEEDS_USERS;
+import static java.util.Objects.nonNull;
 
 @Mapper(componentModel = "spring",
         imports = {URI.class, Set.class, Hasher.class, ByteBuffer.class, HexFormat.class, Instant.class})
@@ -73,12 +75,16 @@ public interface TechwatchMapper {
         feed.meta(updated, Instant.class).map(DateUtils::toLocalDateTime)
                 .ifPresent(feedsRecord::setFeedLastWatch);
         feed.meta(ETag).ifPresent(feedsRecord::setFeedLastEtag);
-        if (feed.self().name() != null) {
+        if (nonNull(feed.self().name())) {
             feedsRecord.setFeedName(feed.self().name());
         }
-        if (feed.self().description() != null) {
+        if (nonNull(feed.self().description())) {
             feedsRecord.setFeedDescription(feed.self().description());
         }
+        Optional.ofNullable(feed.self().icon())
+                .map(URI::toString)
+                .ifPresent(feedsRecord::setFeedIcon);
+
         feedsRecord.setFeedUrl(feed.self().location().toString());
 
         return feedsRecord;

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/config/TechwatchMapper.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/config/TechwatchMapper.java
@@ -53,12 +53,16 @@ public interface TechwatchMapper {
         String lastETag = (r.indexOf(FEEDS.FEED_LAST_ETAG) >= 0 && r.get(FEEDS.FEED_LAST_ETAG) != null)
                 ? r.get(FEEDS.FEED_LAST_ETAG) : null;
 
+        URI icon = (r.indexOf(FEEDS.FEED_ICON) >= 0 && r.get(FEEDS.FEED_ICON) != null)
+                ? URI.create(r.get(FEEDS.FEED_ICON)) : URI.create("/favicon.ico");
+
         assert lastPublication != null : "Last publication date cannot be null !";
 
         WebFeed webFeed = WebFeed.builder()
                 .name(name)
                 .description(r.get(FEEDS.FEED_DESCRIPTION))
                 .location(URI.create(r.get(FEEDS.FEED_URL)))
+                .icon(icon)
                 .tags(tags)
                 .build();
 

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/config/TechwatchMapper.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/config/TechwatchMapper.java
@@ -54,7 +54,7 @@ public interface TechwatchMapper {
                 ? r.get(FEEDS.FEED_LAST_ETAG) : null;
 
         URI icon = (r.indexOf(FEEDS.FEED_ICON) >= 0 && r.get(FEEDS.FEED_ICON) != null)
-                ? URI.create(r.get(FEEDS.FEED_ICON)) : URI.create("/favicon.ico");
+                ? URI.create(r.get(FEEDS.FEED_ICON)) : null;
 
         assert lastPublication != null : "Last publication date cannot be null !";
 

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/controllers/GraphQLFeedsController.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/controllers/GraphQLFeedsController.java
@@ -139,10 +139,12 @@ public class GraphQLFeedsController {
     @MutationMapping
     @PreAuthorize("hasAnyRole('USER', 'MANAGER', 'ADMIN')")
     public Mono<Entity<WebFeed>> feedUpdate(
-            @Argument String id, @Argument String name, @Argument String description, @Argument Collection<String> tags) {
+            @Argument String id, @Argument String name, @Argument String description, @Argument String icon, @Argument Collection<String> tags) {
         Set<String> tagsSet = Optional.ofNullable(tags).map(Set::copyOf).orElse(Set.of());
         return feedService.get(id)
-                .map(feed -> List.of(feed.convert(e -> e.toBuilder().name(name).description(description).tags(tagsSet).build())))
+                .map(feed -> List.of(feed.convert(e -> e.toBuilder()
+                        .name(name).description(description).icon(URI.create(icon)).tags(tagsSet)
+                        .build())))
                 .flatMapMany(feedService::subscribe)
                 .next();
     }

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/controllers/GraphQLFeedsController.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/controllers/GraphQLFeedsController.java
@@ -43,6 +43,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 
 @Controller
 @RequiredArgsConstructor
@@ -116,7 +117,7 @@ public class GraphQLFeedsController {
         }
 
         URI uri = URI.create(feedForm.location());
-        URI icon = URI.create(feedForm.icon());
+        URI icon = (nonNull(feedForm.icon())) ? URI.create(feedForm.icon()) : null;
         Set<String> tags = Optional.ofNullable(feedForm.tags()).map(Set::copyOf).orElseGet(Set::of);
         var entity = Entity.identify(WebFeed.builder()
                         .location(uri)

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/controllers/GraphQLFeedsController.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/controllers/GraphQLFeedsController.java
@@ -116,11 +116,14 @@ public class GraphQLFeedsController {
         }
 
         URI uri = URI.create(feedForm.location());
+        URI icon = URI.create(feedForm.icon());
         Set<String> tags = Optional.ofNullable(feedForm.tags()).map(Set::copyOf).orElseGet(Set::of);
         var entity = Entity.identify(WebFeed.builder()
                         .location(uri)
                         .tags(tags)
                         .name(feedForm.name())
+                        .description(feedForm.description())
+                        .icon(icon)
                         .build())
                 .withId(Hasher.identify(uri));
         return feedService.addAndSubscribe(Collections.singleton(entity)).next();

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/model/FeedForm.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/model/FeedForm.java
@@ -9,6 +9,7 @@ public record FeedForm(
         @NotBlank String name,
         @NotBlank @URL String location,
         String description,
+        @URL String icon,
         Set<String> tags
 ) {
 }

--- a/sandside/src/main/resources/db/migration/V2_2_202502231146__add_icon_to_feeds.sql
+++ b/sandside/src/main/resources/db/migration/V2_2_202502231146__add_icon_to_feeds.sql
@@ -1,0 +1,1 @@
+alter table FEEDS add COLUMN FEED_ICON varchar(2083);

--- a/sandside/src/main/resources/graphql/scraper/scraper.graphqls
+++ b/sandside/src/main/resources/graphql/scraper/scraper.graphqls
@@ -4,6 +4,7 @@ type AtomFeed {
     description: String,
     author: String,
     link: URI!
+    icon: URI!
 }
 
 type AtomEntry {

--- a/sandside/src/main/resources/graphql/techwatch/feeds.graphqls
+++ b/sandside/src/main/resources/graphql/techwatch/feeds.graphqls
@@ -4,6 +4,7 @@ type Feed {
     name: String,
     description: String,
     location: String!,
+    icon: String,
     tags: [String],
     error: ScrapingError,
 }
@@ -12,6 +13,7 @@ input FeedForm {
     name: String
     location: String
     description: String
+    icon: String
     tags: [String]
 }
 
@@ -38,7 +40,7 @@ extend type Query {
 
 extend type Mutation {
     feedAddAndSubscribe(feed: FeedForm): Feed
-    feedUpdate(id: ID, name: String, description: String, tags: [String]): Feed
+    feedUpdate(id: ID, name: String, description: String, icon: String, tags: [String]): Feed
     feedDelete(ids: [ID]): [Feed]
     subscribe(id: ID, name: String, tags: [String]): Feed
 }

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/opml/domain/OpmlServiceImplTest.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/opml/domain/OpmlServiceImplTest.java
@@ -5,7 +5,7 @@ import fr.ght1pc9kc.baywatch.opml.api.OpmlService;
 import fr.ght1pc9kc.baywatch.security.api.AuthenticationFacade;
 import fr.ght1pc9kc.baywatch.security.infra.adapters.SpringAuthenticationContext;
 import fr.ght1pc9kc.baywatch.techwatch.api.model.WebFeed;
-import fr.ght1pc9kc.baywatch.techwatch.infra.persistence.FeedRepository;
+import fr.ght1pc9kc.baywatch.techwatch.infra.adapters.persistence.FeedRepository;
 import fr.ght1pc9kc.baywatch.tests.samples.FeedSamples;
 import fr.ght1pc9kc.baywatch.tests.samples.UserSamples;
 import fr.ght1pc9kc.entity.api.Entity;

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/scraper/domain/actions/PersistErrorsHandlerTest.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/scraper/domain/actions/PersistErrorsHandlerTest.java
@@ -42,14 +42,14 @@ class PersistErrorsHandlerTest {
         Mono<Void> step = tested.after(new ScrapResult(1, List.of(
                 new FeedScrapingException(new AtomFeed(
                         "42", "Obiwan Kenobi", null, null,
-                        URI.create("https://jedi.com/"), null),
+                        URI.create("https://jedi.com/"), null, null),
                         new RuntimeException("test")),
                 new FeedScrapingException(new AtomFeed(
                         "42", "Obiwan Kenobi", null, null,
-                        URI.create("https://jedi.com/"), null),
+                        URI.create("https://jedi.com/"), null, null),
                         new RuntimeException("404 Not found")),
                 new FeedScrapingException(new AtomFeed(
-                        "41", "Obiwan Kenobi", null, null, null, null),
+                        "41", "Obiwan Kenobi", null, null, null, null, null),
                         new IllegalArgumentException("test")),
                 new NewsScrapingException(new AtomEntry(
                         "66", "Kylo Ren", null, null, null,

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/scraper/domain/actions/ScrapingLoggerHandlerTest.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/scraper/domain/actions/ScrapingLoggerHandlerTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ScrapingLoggerHandlerTest {
     private final ListAppender<ILoggingEvent> mockLogAppender = new ListAppender<>();
     private ScrapingLoggerHandler tested;
-    private Logger logger = (Logger) LoggerFactory.getLogger(ScrapingLoggerHandler.class);
+    private final Logger logger = (Logger) LoggerFactory.getLogger(ScrapingLoggerHandler.class);
     private Level originalLevel;
 
     @BeforeEach

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/scraper/domain/filters/ImageLinkValidationFilterTest.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/scraper/domain/filters/ImageLinkValidationFilterTest.java
@@ -1,5 +1,6 @@
 package fr.ght1pc9kc.baywatch.scraper.domain.filters;
 
+import fr.ght1pc9kc.baywatch.scraper.infra.adapters.LinkCheckAdapter;
 import fr.ght1pc9kc.baywatch.techwatch.api.model.RawNews;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,7 @@ class ImageLinkValidationFilterTest {
     @Test
     void should_validate_link_successfully() {
         ImageLinkValidationFilter tested = new ImageLinkValidationFilter(
-                WebClient.builder().exchangeFunction(new SuccessExchangeFunction()).build());
+                new LinkCheckAdapter(WebClient.builder().exchangeFunction(new SuccessExchangeFunction()).build()));
 
         RawNews rawNews = RawNews.builder().id("0").link(URI.create("https://www.jedi.com/"))
                 .image(URI.create("https://www.jedi.com/")).build();
@@ -33,7 +34,7 @@ class ImageLinkValidationFilterTest {
     @Test
     void should_validate_link_with_query_parameters() {
         ImageLinkValidationFilter tested = new ImageLinkValidationFilter(
-                WebClient.builder().exchangeFunction(new SuccessExchangeFunction()).build());
+                new LinkCheckAdapter(WebClient.builder().exchangeFunction(new SuccessExchangeFunction()).build()));
 
         RawNews rawNews = RawNews.builder().id("0").link(URI.create("https://www.jedi.com/"))
                 .image(URI.create("https://www.jedi.com/image.jpg?w=42")).build();
@@ -46,7 +47,7 @@ class ImageLinkValidationFilterTest {
     @Test
     void should_validate_link_with_illegal_scheme() {
         ImageLinkValidationFilter tested = new ImageLinkValidationFilter(
-                WebClient.builder().exchangeFunction(new SuccessExchangeFunction()).build());
+                new LinkCheckAdapter(WebClient.builder().exchangeFunction(new SuccessExchangeFunction()).build()));
 
         RawNews rawNews = RawNews.builder().id("0").link(URI.create("https://www.jedi.com/"))
                 .image(URI.create("file://www.jedi.com/")).build();
@@ -68,7 +69,7 @@ class ImageLinkValidationFilterTest {
     @Test
     void should_validate_link_redirection() {
         ImageLinkValidationFilter tested = new ImageLinkValidationFilter(
-                WebClient.builder().exchangeFunction(new RedirectExchangeFunction()).build());
+                new LinkCheckAdapter(WebClient.builder().exchangeFunction(new RedirectExchangeFunction()).build()));
 
         RawNews rawNews = RawNews.builder().id("0").link(URI.create("https://www.jedi.com/"))
                 .image(URI.create("https://www.jedi.com/")).build();
@@ -90,7 +91,7 @@ class ImageLinkValidationFilterTest {
     @Test
     void should_validate_link_error() {
         ImageLinkValidationFilter tested = new ImageLinkValidationFilter(
-                WebClient.builder().exchangeFunction(new ErrorExchangeFunction()).build());
+                new LinkCheckAdapter(WebClient.builder().exchangeFunction(new ErrorExchangeFunction()).build()));
 
         RawNews rawNews = RawNews.builder().id("0").link(URI.create("https://www.jedi.com/"))
                 .image(URI.create("https://www.jedi.com/")).build();

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/techwatch/domain/FeedServiceImplTest.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/techwatch/domain/FeedServiceImplTest.java
@@ -6,6 +6,7 @@ import fr.ght1pc9kc.baywatch.common.domain.QueryContext;
 import fr.ght1pc9kc.baywatch.security.api.AuthenticationFacade;
 import fr.ght1pc9kc.baywatch.security.domain.exceptions.UnauthenticatedUser;
 import fr.ght1pc9kc.baywatch.techwatch.api.FeedService;
+import fr.ght1pc9kc.baywatch.techwatch.api.ImageProxyService;
 import fr.ght1pc9kc.baywatch.techwatch.api.model.WebFeed;
 import fr.ght1pc9kc.baywatch.techwatch.domain.ports.FeedPersistencePort;
 import fr.ght1pc9kc.baywatch.techwatch.domain.ports.ScraperServicePort;
@@ -50,6 +51,7 @@ class FeedServiceImplTest {
 
     private final FeedPersistencePort mockFeedRepository = mock(FeedPersistencePort.class);
     private final AuthenticationFacade mockAuthFacade = mock(AuthenticationFacade.class);
+    private final ImageProxyService mockImageProxyService = mock(ImageProxyService.class);
 
     private FeedService tested;
 
@@ -76,7 +78,7 @@ class FeedServiceImplTest {
         ScraperServicePort mockScraperService = mock(ScraperServicePort.class);
         when(mockScraperService.fetchFeedData(any())).thenReturn(Mono.just(FeedSamples.JEDI.self()));
         tested = new FeedServiceImpl(mockFeedRepository, mockScraperService, mockAuthFacade, new ListPropertiesCriteriaVisitor() {
-        });
+        }, mockImageProxyService);
     }
 
     @Test

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/techwatch/infra/config/TechwatchMapperTest.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/techwatch/infra/config/TechwatchMapperTest.java
@@ -49,8 +49,9 @@ class TechwatchMapperTest {
     @Test
     void should_map_AtomFeed_to_Feed() {
         Assertions.assertThat(tested.getFeedFromAtom(new AtomFeed(null,
-                "Jedi Channel", "May the force be with you",
-                "Obiwan Kenobi", URI.create("https://jedi.com/feed/"), Instant.parse("2024-02-25T17:11:42Z")))
+                "Jedi Channel", "May the force be with you", "Obiwan Kenobi",
+                URI.create("https://jedi.com/feed/"), URI.create("https://jedi.com/favicon.ico"),
+                Instant.parse("2024-02-25T17:11:42Z")))
         ).isEqualTo(WebFeed.builder()
                 .name("Jedi Channel")
                 .tags(Set.of())

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/techwatch/infra/config/TechwatchMapperTest.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/techwatch/infra/config/TechwatchMapperTest.java
@@ -58,6 +58,7 @@ class TechwatchMapperTest {
                 .name("Jedi Channel")
                 .description("May the force be with you")
                 .location(URI.create("https://jedi.com/feed/"))
+                .icon(URI.create("https://jedi.com/favicon.ico"))
                 .build());
     }
 }

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/techwatch/infra/controllers/GraphQLFeedsControllerTest.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/techwatch/infra/controllers/GraphQLFeedsControllerTest.java
@@ -108,11 +108,21 @@ class GraphQLFeedsControllerTest {
                 .variable("feed", null)
                 .execute().errors().expect(ex -> ex.getErrorType() == ErrorType.INTERNAL_ERROR);
 
+        gqlClient.documentName("feedsServiceTest")
+                .operationName("FeedAddAndSubscribe")
+                .variable("feed", Map.of(
+                        "name", "Jedi.com",
+                        "location", "https://jedi.com/atom.xml",
+                        "description", "Jedi News Feed",
+                        "tags", List.of("light", "good")))
+                .execute().path("feedAddAndSubscribe").hasValue();
+
         GraphQlTester.Response executed = gqlClient.documentName("feedsServiceTest")
                 .operationName("FeedAddAndSubscribe")
                 .variable("feed", Map.of(
                         "name", "Jedi.com",
                         "location", "https://jedi.com/atom.xml",
+                        "icon", "https://jedi.com/favicon.png",
                         "description", "Jedi News Feed",
                         "tags", List.of("light", "good")))
                 .execute();
@@ -120,6 +130,7 @@ class GraphQLFeedsControllerTest {
         Object response = executed.path("feedAddAndSubscribe")
                 .entity(Object.class)
                 .get();
+
         String actual = objectMapper.writeValueAsString(response);
         Assertions.assertThat(actual).isNotBlank();
         assertThatJson(actual)

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/techwatch/infra/persistence/FeedRepositoryTest.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/techwatch/infra/persistence/FeedRepositoryTest.java
@@ -7,6 +7,7 @@ import fr.ght1pc9kc.baywatch.dsl.tables.records.FeedsRecord;
 import fr.ght1pc9kc.baywatch.dsl.tables.records.FeedsUsersPropertiesRecord;
 import fr.ght1pc9kc.baywatch.dsl.tables.records.FeedsUsersRecord;
 import fr.ght1pc9kc.baywatch.techwatch.api.model.WebFeed;
+import fr.ght1pc9kc.baywatch.techwatch.infra.adapters.persistence.FeedRepository;
 import fr.ght1pc9kc.baywatch.techwatch.infra.config.TechwatchMapper;
 import fr.ght1pc9kc.baywatch.techwatch.infra.model.FeedDeletedResult;
 import fr.ght1pc9kc.baywatch.techwatch.infra.model.FeedProperties;

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/techwatch/infra/persistence/NewsRepositoryTest.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/techwatch/infra/persistence/NewsRepositoryTest.java
@@ -11,6 +11,7 @@ import fr.ght1pc9kc.baywatch.techwatch.api.model.News;
 import fr.ght1pc9kc.baywatch.techwatch.api.model.RawNews;
 import fr.ght1pc9kc.baywatch.techwatch.api.model.State;
 import fr.ght1pc9kc.baywatch.common.domain.QueryContext;
+import fr.ght1pc9kc.baywatch.techwatch.infra.adapters.persistence.NewsRepository;
 import fr.ght1pc9kc.baywatch.tests.samples.infra.FeedRecordSamples;
 import fr.ght1pc9kc.baywatch.tests.samples.infra.FeedsUsersRecordSample;
 import fr.ght1pc9kc.baywatch.tests.samples.infra.NewsRecordSamples;

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/techwatch/infra/persistence/StateRepositoryTest.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/techwatch/infra/persistence/StateRepositoryTest.java
@@ -4,6 +4,7 @@ import fr.ght1pc9kc.baywatch.common.domain.Hasher;
 import fr.ght1pc9kc.baywatch.techwatch.api.model.Flags;
 import fr.ght1pc9kc.baywatch.techwatch.api.model.State;
 import fr.ght1pc9kc.baywatch.common.domain.QueryContext;
+import fr.ght1pc9kc.baywatch.techwatch.infra.adapters.persistence.StateRepository;
 import fr.ght1pc9kc.baywatch.tests.samples.infra.FeedRecordSamples;
 import fr.ght1pc9kc.baywatch.tests.samples.infra.FeedsUsersRecordSample;
 import fr.ght1pc9kc.baywatch.tests.samples.infra.NewsRecordSamples;

--- a/seaside/pom.xml
+++ b/seaside/pom.xml
@@ -98,7 +98,7 @@
                 <executions>
                     <execution>
                         <id>NPM Install</id>
-                        <phase>generate-resources</phase>
+                        <phase>process-resources</phase>
                         <configuration>
                             <executable>yarn</executable>
                             <arguments>
@@ -112,7 +112,7 @@
                     </execution>
                     <execution>
                         <id>Vite build</id>
-                        <phase>generate-resources</phase>
+                        <phase>compile</phase>
                         <configuration>
                             <executable>yarn</executable>
                             <arguments>
@@ -125,7 +125,7 @@
                     </execution>
                     <execution>
                         <id>Vitest Coverage</id>
-                        <phase>generate-resources</phase>
+                        <phase>test</phase>
                         <configuration>
                             <executable>yarn</executable>
                             <arguments>

--- a/seaside/src/assets/styles/index.css
+++ b/seaside/src/assets/styles/index.css
@@ -1,8 +1,12 @@
 @import "tailwindcss";
+
 @plugin "daisyui";
 @plugin "daisyui/theme" {
     name: "baywatch";
     default: true;
+    prefersdark: true;
+    color-scheme: dark;
+        
     --color-primary: #ff5555;
     --color-primary-content: #ffeee9;
     --color-secondary: #e5e7eb;
@@ -16,6 +20,7 @@
     --color-success: #009485;
     --color-warning: #ff9900;
     --color-error: #d92b3a;
+    --color-error-content: oklch(88% 0.062 18.334);
 }
 
 @layer components {

--- a/seaside/src/assets/styles/index.css
+++ b/seaside/src/assets/styles/index.css
@@ -6,7 +6,7 @@
     default: true;
     prefersdark: true;
     color-scheme: dark;
-        
+
     --color-primary: #ff5555;
     --color-primary-content: #ffeee9;
     --color-secondary: #e5e7eb;

--- a/seaside/src/common/components/ModalWindow.vue
+++ b/seaside/src/common/components/ModalWindow.vue
@@ -1,6 +1,6 @@
 <template>
   <dialog class="modal bg-base-200/50 backdrop-blur-xs text-primary-content" v-if="isOpened"
-          :class="{'opacity-100 pointer-events-auto visible': isOpened}">
+          :class="{'opacity-100 pointer-events-auto visible': isOpened}" :open="isOpened">
     <div class="modal-box flex-col space-x-0 overflow-visible">
       <h3 class="font-bold text-lg -mt-2 mb-2">{{ title }}</h3>
       <slot></slot>

--- a/seaside/src/common/components/alertdialog/AlertDialog.vue
+++ b/seaside/src/common/components/alertdialog/AlertDialog.vue
@@ -1,59 +1,60 @@
 <template>
-    <div v-if="instance.isFired" :class="{'opacity-100 pointer-events-auto visible': instance.isFired}"
-         class="modal compact flex-col space-x-0">
-        <div class="modal-box translate-y-0 rounded-none">
-            <p v-html="instance.message"></p>
-            <div v-if="isInfoDialog" class="modal-action">
-                <button class="btn" @click.stop="onClose">Fermer</button>
-            </div>
-            <div v-else-if="isConfirmDialog" class="modal-action">
-                <button class="btn" @click.stop="onCancel">Annuler</button>
-                <button class="btn btn-error" @click.stop="onConfirm">{{ instance.confirmLabel }}</button>
-            </div>
-        </div>
+  <dialog v-if="instance.isFired" :class="{'opacity-100 pointer-events-auto visible': instance.isFired}"
+          :open="instance.isFired"
+          class="modal compact flex-col space-x-0">
+    <div class="modal-box translate-y-0 rounded-none">
+      <p v-html="instance.message"></p>
+      <div v-if="isInfoDialog" class="modal-action">
+        <button class="btn" @click.stop="onClose">Fermer</button>
+      </div>
+      <div v-else-if="isConfirmDialog" class="modal-action">
+        <button class="btn" @click.stop="onCancel">Annuler</button>
+        <button class="btn btn-error" @click.stop="onConfirm">{{ instance.confirmLabel }}</button>
+      </div>
     </div>
+  </dialog>
 </template>
 <script lang="ts">
-import {Component, Vue} from "vue-facing-decorator";
+import { Component, Vue } from 'vue-facing-decorator';
 import {
-    alertInjectionKey,
-    AlertResponse,
-    AlertType,
-    IAlertDialog
-} from "@/common/components/alertdialog/AlertDialog.types";
-import {inject} from "vue";
+  alertInjectionKey,
+  AlertResponse,
+  AlertType,
+  IAlertDialog,
+} from '@/common/components/alertdialog/AlertDialog.types';
+import { inject } from 'vue';
 
 @Component({
-    name: 'AlertDialog',
-    setup() {
-        return {
-            instance: inject(alertInjectionKey),
-        }
-    }
+  name: 'AlertDialog',
+  setup() {
+    return {
+      instance: inject(alertInjectionKey),
+    };
+  },
 })
 export default class AlertDialog extends Vue {
 
-    instance: IAlertDialog;
+  instance: IAlertDialog;
 
-    get isInfoDialog(): boolean {
-        return this.instance.alertType === AlertType.INFO;
-    }
+  get isInfoDialog(): boolean {
+    return this.instance.alertType === AlertType.INFO;
+  }
 
-    get isConfirmDialog(): boolean {
-        return this.instance.alertType === AlertType.CONFIRM_DELETE;
-    }
+  get isConfirmDialog(): boolean {
+    return this.instance.alertType === AlertType.CONFIRM_DELETE;
+  }
 
-    private onClose(): void {
-        this.instance.close(AlertResponse.OK);
-    }
+  private onClose(): void {
+    this.instance.close(AlertResponse.OK);
+  }
 
-    private onConfirm(): void {
-        this.instance.close(AlertResponse.CONFIRM);
-    }
+  private onConfirm(): void {
+    this.instance.close(AlertResponse.CONFIRM);
+  }
 
-    private onCancel(): void {
-        this.instance.close(AlertResponse.CANCEL);
-    }
+  private onCancel(): void {
+    this.instance.close(AlertResponse.CANCEL);
+  }
 }
 
 </script>

--- a/seaside/src/configuration/components/feedslist/FeedEditor.vue
+++ b/seaside/src/configuration/components/feedslist/FeedEditor.vue
@@ -16,23 +16,28 @@
               <ArrowPathIcon class="h-6 w-6"/>
             </button>
           </span>
-          <span class="label">
-            <span class="label-text-alt"/>
-            <span class="label-text-alt text-error-content first-letter:capitalize">{{ errors.location }}</span>
-          </span>
+          <div class="label-text-alt w-full text-right text-error-content h-5 first-letter:capitalize">
+            {{ errors.location }}
+          </div>
         </label>
-        <label class="label -mt-6" for="feedName">
+        <label class="label -mt-4" for="feedName">
           <span class="label-text capitalize">{{ t('config.feeds.editor.form.name') }}</span>
         </label>
         <input id="feedName" v-model="feed.name" :class="{'input-error': errors.name}"
                :placeholder="t('config.feeds.editor.form.name.placeholder')"
-               class="input input-bordered placeholder:capitalize"
+               class="input input-bordered placeholder:capitalize w-full"
                type="text">
 
         <label class="label" for="feedDescription">
           <span class="label-text capitalize">{{ t('config.feeds.editor.form.description') }}</span>
         </label>
-        <textarea id="feedDescription" v-model="feed.description" class="textarea textarea-bordered italic" rows="3"/>
+        <div class="flex h-24">
+          <textarea id="feedDescription" v-model="feed.description" class="textarea textarea-bordered italic w-full"
+                    rows="3"/>
+          <figure v-if="feed.icon" class="w-16 max-h-full mx-2">
+            <img :alt="feed.name + ' icon'" :src="feed.icon" class="w-16 object-cover truncate text-transparent"/>
+          </figure>
+        </div>
 
         <TagInput v-model="feed.tags" :available-tags-handler="() => listAvailableTags()"/>
       </fieldset>
@@ -40,8 +45,8 @@
     </form>
     <template v-slot:actions>
       <button class="btn capitalize" @click.stop="resetAndCloseModal">{{ t('dialog.cancel') }}</button>
-      <button class="btn btn-primary capitalize"
-              :disabled="Object.entries(errors).length > 0"
+      <button :disabled="Object.entries(errors).length > 0"
+              class="btn btn-primary capitalize"
               @click="onSaveFeed">{{
           t('config.feeds.editor.form.action.submit')
         }}
@@ -110,7 +115,7 @@ export default class FeedEditor extends Vue {
       this.errors.name = this.t('config.feeds.messages.nameMandatory');
     }
     if (!URL_PATTERN.test(this.feed.location)) {
-      this.errors.location = this.t('config.feeds.messages.locationMustBeURL');;
+      this.errors.location = this.t('config.feeds.messages.locationMustBeURL');
     }
     if (Object.entries(this.errors).length === 0) {
       this.subject?.next(this.feed);
@@ -120,7 +125,7 @@ export default class FeedEditor extends Vue {
 
   private onUriBlur(): void {
     if (!URL_PATTERN.test(this.feed.location)) {
-      this.errors.location = this.t('config.feeds.messages.locationMustBeURL');;
+      this.errors.location = this.t('config.feeds.messages.locationMustBeURL');
       return;
     } else {
       delete this.errors.location;
@@ -130,9 +135,9 @@ export default class FeedEditor extends Vue {
       next: f => Object.assign(this.feed, { ...f, url: this.feed.location }),
       complete: () => this.isFormLock = false,
       error: err => {
-        this.errors.location = this.t(err.code);
         this.isFormLock = false;
-      }
+        this.errors.location = this.t(err.code ?? 'error.server.unknown');
+      },
     });
   }
 

--- a/seaside/src/configuration/components/feedslist/FeedsList.vue
+++ b/seaside/src/configuration/components/feedslist/FeedsList.vue
@@ -100,7 +100,7 @@ export default class FeedsList extends Vue {
           return feedPage.data;
         }),
         map(fs => fs.map(f =>
-            this.modelToView({ icon: new URL(new URL(f.location).origin + '/favicon.ico'), ...f }))),
+            this.modelToView({ icon: new URL(window.location.origin + '/favicon.ico'), ...f }))),
         tap(fs => this.feeds = fs),
     );
   }

--- a/seaside/src/configuration/model/GraphQLScraper.type.ts
+++ b/seaside/src/configuration/model/GraphQLScraper.type.ts
@@ -1,6 +1,7 @@
 export type AtomFeed = {
     title?: string,
     description?: string,
+    icon?: string,
 }
 
 export type ScrapFeedHeaderResponse = {

--- a/seaside/src/configuration/services/FeedService.ts
+++ b/seaside/src/configuration/services/FeedService.ts
@@ -72,17 +72,17 @@ export class FeedService {
 }
 
 const FEED_UPDATE = `#graphql
-mutation FeedUpdate($id: ID, $name: String, $description: String, $tags: [String]) {
-    feedUpdate(id: $id, name: $name, description: $description, tags: $tags) {_id name}
+mutation FeedUpdate($id: ID, $name: String, $description: String, $icon: String, $tags: [String]) {
+    feedUpdate(id: $id, name: $name, description: $description, icon: $icon, tags: $tags) {_id name}
 }`;
 
-export function feedUpdate(id: string, feed: Pick<Feed, 'name' | 'description' | 'tags'>): Observable<Feed> {
-    const { name, description, tags } = feed;
+export function feedUpdate(id: string, feed: Pick<Feed, 'name' | 'description' | 'tags' | 'icon'>): Observable<Feed> {
+    const { name, description, tags, icon } = feed;
     if (id === undefined) {
         return throwError(() => new Error('Feed id is mandatory !'));
     }
 
-    return send<{ feedUpdate: Feed }>(FEED_UPDATE, { id, name, description, tags }).pipe(
+    return send<{ feedUpdate: Feed }>(FEED_UPDATE, { id, name, description, icon, tags }).pipe(
         map(data => data.data.feedUpdate),
         take(1),
     );
@@ -93,8 +93,8 @@ mutation FeedAddAndSubscribe($feed: FeedForm) {
     feedAddAndSubscribe(feed: $feed) {_id name}
 }`;
 
-export function feedAddAndSubscribe(feed: Pick<Feed, 'name' | 'description' | 'tags' | 'location'>): Observable<Feed> {
-    const { name, description, tags, location } = feed;
+export function feedAddAndSubscribe(feed: Pick<Feed, 'name' | 'description' | 'tags' | 'location' | 'icon'>): Observable<Feed> {
+    const { name, description, tags, location, icon } = feed;
 
     return send<{ feedAddAndSubscribe: Feed }>(FEED_ADD_AND_SUBSCRIBE, {
         feed: {
@@ -102,6 +102,7 @@ export function feedAddAndSubscribe(feed: Pick<Feed, 'name' | 'description' | 't
             description,
             tags,
             location,
+            icon,
         },
     }).pipe(
         map(data => data.data.feedAddAndSubscribe),
@@ -126,6 +127,7 @@ query ScrapFeedHeader($link: URI!) {
     scrapFeedHeader(link: $link) {
         title
         description
+        icon
     }
 }`;
 
@@ -141,6 +143,7 @@ export function feedFetchInformation(link?: string): Observable<Feed> {
         map((atom: AtomFeed) => ({
             name: atom.title,
             description: atom.description,
+            icon: atom.icon,
         } as Feed)),
         take(1),
     );

--- a/seaside/src/configuration/services/FeedService.ts
+++ b/seaside/src/configuration/services/FeedService.ts
@@ -15,15 +15,10 @@ export class FeedService {
     query SearchFeedsQuery ($_p: Int = 0, $_pp: Int = ${FeedService.DEFAULT_PER_PAGE}, $_s: String = "name") {
         feedsSearch(_p: $_p, _pp: $_pp, _s: $_s) {
             totalCount
-            entities {_id name description location tags error {
+            entities {_id name description location icon tags error {
                 level since message
             }}
         }
-    }`;
-
-    private static readonly FEED_SUBSCRIBE = `#graphql
-    mutation Subscription($feedId: ID) {
-        subscribe(id: $feedId) {_id name}
     }`;
 
     /**
@@ -43,9 +38,6 @@ export class FeedService {
                     data: of(res.data.feedsSearch.entities).pipe(
                         map(feeds => {
                             feeds.forEach(feed => {
-                                if (!feed.icon) {
-                                    feed.icon = new URL(new URL(feed.location).origin + '/favicon.ico');
-                                }
                                 if (feed.error) {
                                     feed.error.since = new Date(feed.error.since);
                                 }
@@ -58,6 +50,11 @@ export class FeedService {
             take(1),
         );
     }
+
+    private static readonly FEED_SUBSCRIBE = `#graphql
+    mutation Subscription($feedId: ID) {
+        subscribe(id: $feedId) {_id name}
+    }`;
 
     public subscribe(id: string): Observable<Feed> {
         if (id === undefined) {

--- a/seaside/src/locales/main_en-US.ts
+++ b/seaside/src/locales/main_en-US.ts
@@ -6,6 +6,7 @@ export const en_US = {
     'aside.register': 'Register',
     'aside.teams': 'teams',
     'dialog.cancel': 'cancel',
+    'error.server.unknown': 'Unknown server error !',
     'main.application': 'Baywatch',
     'sidenav.filters': 'filters',
     'sidenav.filters.popular': 'popular',

--- a/seaside/src/locales/main_fr-FR.ts
+++ b/seaside/src/locales/main_fr-FR.ts
@@ -6,6 +6,7 @@ export const fr_FR = {
     'aside.register': 'Nouveau compte',
     'aside.teams': 'équipes',
     'dialog.cancel': 'annuler',
+    'error.server.unknown': 'Erreur serveur inconnue !',
     'main.application': 'Baywatch',
     'sidenav.filters': 'filtres',
     'sidenav.filters.popular': 'populaire',

--- a/seaside/src/techwatch/services/NewsService.ts
+++ b/seaside/src/techwatch/services/NewsService.ts
@@ -10,6 +10,7 @@ import { NewsSearchRequest } from '@/techwatch/model/NewsSearchRequest.type';
 import { SandSideError } from '@/common/errors/SandSideError';
 import { GraphqlResponse } from '@/common/model/GraphqlResponse.type';
 import { send } from '@/common/services/GraphQLClient';
+import { NewsSearchResponse } from '@/techwatch/model/NewsSearchResponse.type';
 
 export function newsMark(id: string, mark: Mark): Observable<NewsState> {
     return rest.put(`/news/${id}/mark/${mark}`).pipe(
@@ -71,7 +72,7 @@ export class NewsService {
     }`;
 
     getAnonymousNews(): Observable<Infinite<News>> {
-        return send(NewsService.NEWS_SEARCH_ANONYMOUS_REQUEST).pipe(
+        return send<NewsSearchResponse>(NewsService.NEWS_SEARCH_ANONYMOUS_REQUEST).pipe(
             map(response => NewsService.graphResponseToInfinite(response)),
             take(1),
         );
@@ -87,16 +88,16 @@ export class NewsService {
         if (page > 0) {
             query._p = page;
         }
-        return send(NewsService.NEWS_SEARCH_REQUEST, query).pipe(
+        return send<NewsSearchResponse>(NewsService.NEWS_SEARCH_REQUEST, query).pipe(
             map(response => NewsService.graphResponseToInfinite(response)),
             take(1),
         );
     }
 
-    private static graphResponseToInfinite<G, T>(response: GraphqlResponse<G>): Infinite<T> {
-        if (!response.errors || response.errors.length === 0) {
+    private static graphResponseToInfinite(response: GraphqlResponse<NewsSearchResponse>): Infinite<News> {
+        if (response.data.newsSearch && (!response.errors || response.errors.length === 0)) {
             const totalCount: number = response.data.newsSearch.totalCount || -1;
-            const data: Observable<T[]> = of(response.data.newsSearch.entities as T[]);
+            const data: Observable<News[]> = of(response.data.newsSearch.entities);
             return {
                 total: totalCount,
                 data: data,

--- a/seaside/tests/unit/configuration/components/profile/ChangePasswordModal.test.ts
+++ b/seaside/tests/unit/configuration/components/profile/ChangePasswordModal.test.ts
@@ -17,7 +17,7 @@ describe('ChangePasswordModal', () => {
         expect(modalWrapper.isVisible()).toBe(false);
 
         await wrapper.setProps({ isOpen: true });
-        expect(modalWrapper.isVisible()).toBe(false);
+        expect(modalWrapper.isVisible()).toBe(true);
         expect(modalWrapper.find('button').exists()).toBe(true);
     });
 });

--- a/seaside/vite.config.ts
+++ b/seaside/vite.config.ts
@@ -40,7 +40,7 @@ export default defineConfig(({ mode }) => ({
                 target: 'http://localhost:8082',
                 toProxy: true,
                 timeout: 0,
-                rewrite: (path) => path.replace(/^\/img/, ''),
+                // rewrite: (path) => path.replace(/^\/img/, ''),
             },
         },
     },

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,6 +4,6 @@ sonar.organization=ght1pc9kc-fr
 sonar.host.url=https://sonarcloud.io
 sonar.coverage.jacoco.xmlReportPaths=**/jacoco.xml
 sonar.coverage.exclusions=**/*.html,**/*.test.*
-sonar.exclusions=**/*.html,seaside/src/locales/**,seaside/dist/**
+sonar.exclusions=**/*.html,seaside/src/locales/**,seaside/dist/**,seaside/src/assets/styles/index.css
 sonar.java.binaries=sandside/target/classes/**
 sonar.java.libraries=sandside/target/dependency


### PR DESCRIPTION
At the moment favicons are retrieved on the fly using the favicon.ico link. But this generates a bunch of errors in the console if the icon doesn't exist and it doesn't handle the case where the site doesn't use the default name either.

It would be nice to be able to do the following:
* For sites that don't yet have icons
* Check if favicon.ico exists
    * If not, look for the icon in the page header
* Store the link to the icon if you have found it
* Use imgProxy to manage a cache for this icon
* Have the front end retrieve an icon error that no longer exists and send it back to the back end for updating (beware of security rules in this case).
