### PR TITLE
feature/248-fix-setting-retrieval-on-new-users

### DIFF
--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/api/AuthenticationFacade.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/api/AuthenticationFacade.java
@@ -12,6 +12,8 @@ import org.springframework.security.web.authentication.preauth.PreAuthenticatedA
 import reactor.core.publisher.Mono;
 import reactor.util.context.Context;
 
+import java.util.Locale;
+
 /**
  * Facade used to get the connected user.
  */

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/domain/UserSettingsServiceImpl.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/domain/UserSettingsServiceImpl.java
@@ -3,17 +3,24 @@ package fr.ght1pc9kc.baywatch.security.domain;
 import fr.ght1pc9kc.baywatch.common.api.exceptions.UnauthorizedException;
 import fr.ght1pc9kc.baywatch.security.api.AuthenticationFacade;
 import fr.ght1pc9kc.baywatch.security.api.UserSettingsService;
+import fr.ght1pc9kc.baywatch.security.api.model.NewsViewType;
 import fr.ght1pc9kc.baywatch.security.api.model.UserSettings;
 import fr.ght1pc9kc.baywatch.security.domain.exceptions.UnauthenticatedUser;
+import fr.ght1pc9kc.baywatch.security.domain.model.AvailableLanguages;
+import fr.ght1pc9kc.baywatch.security.domain.ports.ClientLocalePort;
 import fr.ght1pc9kc.baywatch.security.domain.ports.UserSettingsPersistencePort;
 import fr.ght1pc9kc.entity.api.Entity;
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
 
+import java.util.Comparator;
+import java.util.Locale;
+
 @RequiredArgsConstructor
 public class UserSettingsServiceImpl implements UserSettingsService {
-    private final UserSettingsPersistencePort userServicePersistence;
+    private final UserSettingsPersistencePort userSettingsPersistence;
     private final AuthenticationFacade authenticationFacade;
+    private final ClientLocalePort clientLocalePort;
 
     @Override
     public Mono<Entity<UserSettings>> get(String userId) {
@@ -21,7 +28,8 @@ public class UserSettingsServiceImpl implements UserSettingsService {
                 .switchIfEmpty(Mono.error(() -> new UnauthenticatedUser("")))
                 .filter(user -> user.id().equals(userId))
                 .switchIfEmpty(Mono.error(() -> new UnauthorizedException("You can only request your own settings")))
-                .flatMap(user -> userServicePersistence.get(user.id()));
+                .flatMap(user -> userSettingsPersistence.get(user.id()))
+                .switchIfEmpty(getDefaultUserSettings(userId));
     }
 
     @Override
@@ -30,6 +38,16 @@ public class UserSettingsServiceImpl implements UserSettingsService {
                 .switchIfEmpty(Mono.error(() -> new UnauthenticatedUser("")))
                 .filter(user -> user.id().equals(userId))
                 .switchIfEmpty(Mono.error(() -> new UnauthorizedException("You can only request your own settings")))
-                .flatMap(user -> userServicePersistence.persist(user.id(), userSettings));
+                .flatMap(user -> userSettingsPersistence.persist(user.id(), userSettings));
+    }
+
+    private Mono<Entity<UserSettings>> getDefaultUserSettings(String userId) {
+        return clientLocalePort.getClientLocale().map(clientLocale -> {
+            Locale locale = AvailableLanguages.ALL.stream()
+                    .filter(l -> l.getLanguage().equals(clientLocale.getLanguage()))
+                    .min(Comparator.comparing(Locale::getCountry, Comparator.nullsLast(Comparator.reverseOrder())))
+                    .orElse(AvailableLanguages.DEFAULT);
+            return Entity.identify(new UserSettings(locale, true, NewsViewType.MAGAZINE)).withId(userId);
+        });
     }
 }

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/domain/model/AvailableLanguages.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/domain/model/AvailableLanguages.java
@@ -1,0 +1,15 @@
+package fr.ght1pc9kc.baywatch.security.domain.model;
+
+import lombok.experimental.UtilityClass;
+
+import java.util.List;
+import java.util.Locale;
+
+@UtilityClass
+public class AvailableLanguages {
+    public static final Locale ENGLISH = Locale.US;
+    public static final Locale FRENCH = Locale.FRANCE;
+
+    public static final Locale DEFAULT = ENGLISH;
+    public static final List<Locale> ALL = List.of(ENGLISH, FRENCH);
+}

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/domain/ports/ClientLocalePort.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/domain/ports/ClientLocalePort.java
@@ -1,0 +1,9 @@
+package fr.ght1pc9kc.baywatch.security.domain.ports;
+
+import reactor.core.publisher.Mono;
+
+import java.util.Locale;
+
+public interface ClientLocalePort {
+    Mono<Locale> getClientLocale();
+}

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/infra/adapters/ClientLocaleAdapter.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/infra/adapters/ClientLocaleAdapter.java
@@ -1,0 +1,20 @@
+package fr.ght1pc9kc.baywatch.security.infra.adapters;
+
+import fr.ght1pc9kc.baywatch.common.api.LocaleFacade;
+import fr.ght1pc9kc.baywatch.security.domain.ports.ClientLocalePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.Locale;
+
+@Component
+@RequiredArgsConstructor
+public class ClientLocaleAdapter implements ClientLocalePort {
+    private final LocaleFacade localeFacade;
+
+    @Override
+    public Mono<Locale> getClientLocale() {
+        return localeFacade.getLocale();
+    }
+}

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/infra/adapters/UserSettingsServiceAdapter.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/infra/adapters/UserSettingsServiceAdapter.java
@@ -3,6 +3,7 @@ package fr.ght1pc9kc.baywatch.security.infra.adapters;
 import fr.ght1pc9kc.baywatch.security.api.AuthenticationFacade;
 import fr.ght1pc9kc.baywatch.security.api.UserSettingsService;
 import fr.ght1pc9kc.baywatch.security.domain.UserSettingsServiceImpl;
+import fr.ght1pc9kc.baywatch.security.domain.ports.ClientLocalePort;
 import fr.ght1pc9kc.baywatch.security.domain.ports.UserSettingsPersistencePort;
 import lombok.experimental.Delegate;
 import org.springframework.stereotype.Service;
@@ -12,7 +13,9 @@ public class UserSettingsServiceAdapter implements UserSettingsService {
     @Delegate
     private final UserSettingsService delegate;
 
-    public UserSettingsServiceAdapter(AuthenticationFacade authenticationFacade, UserSettingsPersistencePort persistencePort) {
-        this.delegate = new UserSettingsServiceImpl(persistencePort, authenticationFacade);
+    public UserSettingsServiceAdapter(
+            AuthenticationFacade authenticationFacade, ClientLocalePort clientLocalePort,
+            UserSettingsPersistencePort persistencePort) {
+        this.delegate = new UserSettingsServiceImpl(persistencePort, authenticationFacade, clientLocalePort);
     }
 }

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/security/domain/UserSettingsServiceImplTest.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/security/domain/UserSettingsServiceImplTest.java
@@ -11,6 +11,7 @@ import fr.ght1pc9kc.baywatch.security.domain.ports.UserSettingsPersistencePort;
 import fr.ght1pc9kc.baywatch.tests.samples.UserSamples;
 import fr.ght1pc9kc.entity.api.Entity;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
@@ -23,14 +24,15 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class UserSettingsServiceImplTest {
+    private final UserSettingsPersistencePort mockPersistence = mock(UserSettingsPersistencePort.class);
     private UserSettingsService tested;
     private AuthenticationFacade mockAuthentication;
 
     @BeforeEach
     void setUp() {
-        UserSettingsPersistencePort mockPersistence = mock(UserSettingsPersistencePort.class);
         doReturn(Mono.just(Entity.identify(new UserSettings(Locale.FRENCH, true, NewsViewType.MAGAZINE)).withId(UserSamples.LUKE.id())))
                 .when(mockPersistence).get(anyString());
 
@@ -40,7 +42,7 @@ class UserSettingsServiceImplTest {
         }).when(mockPersistence).persist(anyString(), any(UserSettings.class));
 
         mockAuthentication = mock(AuthenticationFacade.class);
-        ClientLocalePort mockLocale = () -> Mono.just(Locale.FRANCE);
+        ClientLocalePort mockLocale = () -> Mono.just(Locale.FRENCH);
         tested = new UserSettingsServiceImpl(mockPersistence, mockAuthentication, mockLocale);
     }
 
@@ -50,6 +52,19 @@ class UserSettingsServiceImplTest {
 
         StepVerifier.create(tested.get(UserSamples.LUKE.id()))
                 .assertNext(actual -> Assertions.assertThat(actual.id()).isEqualTo(UserSamples.LUKE.id()))
+                .verifyComplete();
+    }
+
+    @Test
+    void should_get_user_default_settings() {
+        when(mockPersistence.get(anyString())).thenReturn(Mono.empty());
+        when(mockAuthentication.getConnectedUser()).thenReturn(Mono.just(UserSamples.LUKE));
+
+        StepVerifier.create(tested.get(UserSamples.LUKE.id()))
+                .assertNext(actual -> SoftAssertions.assertSoftly(softly -> {
+                    softly.assertThat(actual.id()).isEqualTo(UserSamples.LUKE.id());
+                    softly.assertThat(actual.self().preferredLocale()).isEqualTo(Locale.FRANCE);
+                }))
                 .verifyComplete();
     }
 

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/security/domain/UserSettingsServiceImplTest.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/security/domain/UserSettingsServiceImplTest.java
@@ -6,6 +6,7 @@ import fr.ght1pc9kc.baywatch.security.api.UserSettingsService;
 import fr.ght1pc9kc.baywatch.security.api.model.NewsViewType;
 import fr.ght1pc9kc.baywatch.security.api.model.UserSettings;
 import fr.ght1pc9kc.baywatch.security.domain.exceptions.UnauthenticatedUser;
+import fr.ght1pc9kc.baywatch.security.domain.ports.ClientLocalePort;
 import fr.ght1pc9kc.baywatch.security.domain.ports.UserSettingsPersistencePort;
 import fr.ght1pc9kc.baywatch.tests.samples.UserSamples;
 import fr.ght1pc9kc.entity.api.Entity;
@@ -39,7 +40,8 @@ class UserSettingsServiceImplTest {
         }).when(mockPersistence).persist(anyString(), any(UserSettings.class));
 
         mockAuthentication = mock(AuthenticationFacade.class);
-        tested = new UserSettingsServiceImpl(mockPersistence, mockAuthentication);
+        ClientLocalePort mockLocale = () -> Mono.just(Locale.FRANCE);
+        tested = new UserSettingsServiceImpl(mockPersistence, mockAuthentication, mockLocale);
     }
 
     @Test

--- a/seaside/src/security/components/CreateAccountComponent.vue
+++ b/seaside/src/security/components/CreateAccountComponent.vue
@@ -4,19 +4,22 @@
     <div class="m-4 max-w-lg">
       <fieldset class="fieldset">
         <legend class="fieldset-legend capitalize">{{ t('security.register.login') }}</legend>
-        <input v-model="account.login" :class="{'input-error': errors.has('login')}" class="input w-full" type="text"/>
+        <input v-model="account.login" :class="{'input-error': errors.has('login')}" class="input w-full" type="text"
+          @change="errors.delete('login')"/>
         <p class="label">{{ errors.get('login') }}&nbsp;</p>
       </fieldset>
 
       <fieldset class="fieldset">
         <legend class="fieldset-legend capitalize">{{ t('security.register.username') }}</legend>
-        <input v-model="account.name" :class="{'input-error': errors.has('name')}" class="input w-full" type="text"/>
+        <input v-model="account.name" :class="{'input-error': errors.has('name')}" class="input w-full" type="text"
+               @change="errors.delete('name')"/>
         <p class="label">{{ errors.get('name') }}&nbsp;</p>
       </fieldset>
 
       <fieldset class="fieldset">
         <legend class="fieldset-legend capitalize">{{ t('security.register.mail') }}</legend>
-        <input v-model="account.mail" :class="{'input-error': errors.has('mail')}" class="input w-full" type="email"/>
+        <input v-model="account.mail" :class="{'input-error': errors.has('mail')}" class="input w-full" type="email"
+               @change="errors.delete('mail')"/>
         <p class="label">{{ errors.get('mail') }}&nbsp;</p>
       </fieldset>
 


### PR DESCRIPTION
### **Fixes in `sandside`:**
- Ensured that **default settings** are properly retrieved and applied for newly created users.
- Validated and corrected the logic for selecting locales:
    - Now guarantees that only existing and valid locales are chosen.
    - This prevents misconfigurations and enhances locale reliability.

### **Fixes in `seaside`:**
- Resolved an error occurring in the **new account creation form**:
    - Fixed improper handling or validation of inputs, ensuring smoother user interactions during account registration.

### **Additional Notes:**
- These fixes contribute to a more robust and user-friendly onboarding experience for new users.
- With these adjustments, we ensure better locale consistency and eliminate errors in critical user-facing components.

