### PR TITLE
feature/241-fix-clip-after-add-standalone

### DIFF
--- a/.run/BaywatchApplication.run.xml
+++ b/.run/BaywatchApplication.run.xml
@@ -8,7 +8,7 @@
       <env name="BAYWATCH_IMGPROXY_SALT" value="c20a3becb08164a79bffa4" />
       <env name="BAYWATCH_IMGPROXY_SIGNKEY" value="ad27d1a476e2d0f6326c76f275ed" />
       <env name="BAYWATCH_INDEXER_ENABLE" value="true" />
-      <env name="BAYWATCH_SCRAPER_ENABLE" value="true" />
+      <env name="BAYWATCH_SCRAPER_ENABLE" value="false" />
       <env name="CONSOLE_LOG_PATTERN" value="%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd'T'HH:mm:ss.SSSXXX}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr(---){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}" />
       <env name="SPRING_THREADS_VIRTUAL_ENABLED" value="true" />
     </envs>

--- a/sandside/pom.xml
+++ b/sandside/pom.xml
@@ -299,7 +299,7 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin> <!-- Only present in order to create target dir for flyway -->
+            <plugin> <!-- Only present to create target dir for flyway -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/common/api/model/BaywatchLogsMarkers.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/common/api/model/BaywatchLogsMarkers.java
@@ -7,4 +7,5 @@ import org.slf4j.MarkerFactory;
 @UtilityClass
 public class BaywatchLogsMarkers {
     public static final Marker PERFORMANCE = MarkerFactory.getMarker("performance");
+    public static final Marker AUDIT = MarkerFactory.getMarker("audit");
 }

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/common/api/model/FeedMeta.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/common/api/model/FeedMeta.java
@@ -8,9 +8,11 @@ import java.time.Instant;
 @RequiredArgsConstructor
 @SuppressWarnings("java:S115")
 public enum FeedMeta implements TypedMeta {
-    ETag(String.class),
     createdBy(String.class),
-    updated(Instant.class);
+    ETag(String.class),
+    updated(Instant.class),
+    visible(Boolean.class),
+    ;
 
     private final Class<?> type;
 

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/domain/UserServiceImpl.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/domain/UserServiceImpl.java
@@ -15,8 +15,10 @@ import fr.ght1pc9kc.baywatch.security.domain.exceptions.ConstraintViolationPersi
 import fr.ght1pc9kc.baywatch.security.domain.exceptions.UnauthenticatedUser;
 import fr.ght1pc9kc.baywatch.security.domain.exceptions.UnauthorizedOperation;
 import fr.ght1pc9kc.baywatch.security.domain.exceptions.UserCreateException;
+import fr.ght1pc9kc.baywatch.security.domain.model.PersonalFeed;
 import fr.ght1pc9kc.baywatch.security.domain.ports.AuthorizationPersistencePort;
 import fr.ght1pc9kc.baywatch.security.domain.ports.NotificationPort;
+import fr.ght1pc9kc.baywatch.security.domain.ports.TechwatchModulePort;
 import fr.ght1pc9kc.baywatch.security.domain.ports.UserPersistencePort;
 import fr.ght1pc9kc.entity.api.Entity;
 import fr.ght1pc9kc.juery.api.Criteria;
@@ -54,6 +56,7 @@ public final class UserServiceImpl implements UserService, AuthorizationService 
 
     private final UserPersistencePort userRepository;
     private final AuthorizationPersistencePort authorizationRepository;
+    private final TechwatchModulePort techwatchModulePort;
     private final NotificationPort notificationPort;
     private final AuthenticationFacade authFacade;
     private final PasswordService passwordService;
@@ -107,6 +110,10 @@ public final class UserServiceImpl implements UserService, AuthorizationService 
 
                 .flatMap(entity -> userRepository.persist(List.of(entity)).single())
                 .flatMap(ignore -> grants(userId, user.roles()))
+                .flatMap(createdUser ->
+                        techwatchModulePort.addAndSubscribePersonalFeed(PersonalFeed.of(createdUser))
+                                .contextWrite(authFacade.withAuthentication(createdUser))
+                                .thenReturn(createdUser))
                 .onErrorMap(ConstraintViolationPersistenceException.class, e ->
                         new UserCreateException(
                                 String.format("Unable to create User, %s unavailable !", e.getPropertyField()),

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/domain/UserServiceImpl.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/domain/UserServiceImpl.java
@@ -39,6 +39,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 
 import static fr.ght1pc9kc.baywatch.common.api.DefaultMeta.NO_ONE;
+import static fr.ght1pc9kc.baywatch.common.api.model.BaywatchLogsMarkers.AUDIT;
 import static fr.ght1pc9kc.baywatch.common.api.model.EntitiesProperties.ID;
 import static fr.ght1pc9kc.baywatch.common.api.model.EntitiesProperties.ROLES;
 import static fr.ght1pc9kc.baywatch.common.api.model.UserMeta.createdAt;
@@ -176,15 +177,31 @@ public final class UserServiceImpl implements UserService, AuthorizationService 
 
     @Override
     public Flux<Entity<User>> delete(Collection<String> ids) {
-        return authorizeSelfData(ids)
-                .flatMapMany(u -> userRepository.list(QueryContext.all(Criteria.property(ID).in(ids))))
-                .switchIfEmpty(Flux.error(new NoSuchElementException(String.format("Unable to find users %s :", ids))))
-                .collectList()
-                .flatMapMany(users -> Flux.fromIterable(users)
-                        .map(Entity::id)
+        return authorizeSelfData(ids).flatMapMany(operator ->
+                userRepository.list(QueryContext.all(Criteria.property(ID).in(ids)))
+                        .switchIfEmpty(Flux.error(new NoSuchElementException(String.format("Unable to find users %s :", ids))))
                         .collectList()
-                        .flatMap(userRepository::delete)
-                        .thenMany(Flux.fromIterable(users)));
+                        .flatMapMany(users -> Flux.fromIterable(users)
+                                .map(Entity::id)
+                                .collectList()
+                                .flatMap(userRepository::delete)
+                                .thenMany(Flux.fromIterable(users)))
+                        .flatMap(user -> techwatchModulePort.unsubscribePersonalFeed(user)
+                                .contextWrite(authFacade.withAuthentication(user))
+                                .thenReturn(user))
+                        .flatMap(user -> techwatchModulePort.deletePersonalFeed(user)
+                                .contextWrite(AuthenticationFacade.withSystemAuthentication())
+                                .thenReturn(user))
+
+                        .doOnNext(user -> log.atWarn().addMarker(AUDIT)
+                                .addKeyValue("operator", operator.id())
+                                .addKeyValue("type", "User")
+                                .addKeyValue("action", "delete")
+                                .addKeyValue("id", user.id())
+                                .addArgument(user.self().login())
+                                .addArgument(operator.self().login())
+                                .log("Deleted user {} by {}"))
+        );
     }
 
     @Override

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/domain/UserServiceImpl.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/domain/UserServiceImpl.java
@@ -109,8 +109,8 @@ public final class UserServiceImpl implements UserService, AuthorizationService 
                                 .meta(createdBy, currentUserId)
                                 .withId(userId)))
 
-                .flatMap(entity -> userRepository.persist(List.of(entity)).single())
-                .flatMap(ignore -> grants(userId, user.roles()))
+                .flatMap(createdUser -> userRepository.persist(List.of(createdUser)).single())
+                .flatMap(createdUser -> grants(userId, user.roles()).thenReturn(createdUser))
                 .flatMap(createdUser ->
                         techwatchModulePort.addAndSubscribePersonalFeed(PersonalFeed.of(createdUser))
                                 .contextWrite(authFacade.withAuthentication(createdUser))

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/domain/model/PersonalFeed.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/domain/model/PersonalFeed.java
@@ -1,0 +1,35 @@
+package fr.ght1pc9kc.baywatch.security.domain.model;
+
+import fr.ght1pc9kc.baywatch.security.api.model.User;
+import fr.ght1pc9kc.entity.api.Entity;
+
+import java.net.URI;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+public record PersonalFeed(
+        String id,
+        String name,
+        String description,
+        URI icon,
+        URI location,
+        boolean visible
+) {
+    public static PersonalFeed of(Entity<User> user) {
+        URI icon;
+        try {
+            MessageDigest md5 = MessageDigest.getInstance("MD5");
+            md5.update(user.self().mail().getBytes());
+            String gravatar = HexFormat.of().formatHex(md5.digest());
+            icon = URI.create("https://www.gravatar.com/avatar/" + gravatar + "?s=96&d=retro");
+        } catch (NoSuchAlgorithmException e) {
+            icon = URI.create("https://www.gravatar.com/avatar/" + user.id() + "?s=96&d=retro");
+        }
+        return new PersonalFeed(
+                user.id(), user.self().name() + "(personal)",
+                "Personal Baywatch pocket for you",
+                icon, URI.create("https://localhost/" + user.id()),
+                false);
+    }
+}

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/domain/model/PersonalFeed.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/domain/model/PersonalFeed.java
@@ -19,6 +19,7 @@ public record PersonalFeed(
     public static PersonalFeed of(Entity<User> user) {
         URI icon;
         try {
+            @SuppressWarnings("java:S4790")
             MessageDigest md5 = MessageDigest.getInstance("MD5");
             md5.update(user.self().mail().getBytes());
             String gravatar = HexFormat.of().formatHex(md5.digest());

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/domain/ports/TechwatchModulePort.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/domain/ports/TechwatchModulePort.java
@@ -1,8 +1,14 @@
 package fr.ght1pc9kc.baywatch.security.domain.ports;
 
+import fr.ght1pc9kc.baywatch.security.api.model.User;
 import fr.ght1pc9kc.baywatch.security.domain.model.PersonalFeed;
+import fr.ght1pc9kc.entity.api.Entity;
 import reactor.core.publisher.Mono;
 
 public interface TechwatchModulePort {
     Mono<Void> addAndSubscribePersonalFeed(PersonalFeed personalFeed);
+
+    Mono<Void> unsubscribePersonalFeed(Entity<User> user);
+
+    Mono<Void> deletePersonalFeed(Entity<User> user);
 }

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/domain/ports/TechwatchModulePort.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/domain/ports/TechwatchModulePort.java
@@ -1,0 +1,8 @@
+package fr.ght1pc9kc.baywatch.security.domain.ports;
+
+import fr.ght1pc9kc.baywatch.security.domain.model.PersonalFeed;
+import reactor.core.publisher.Mono;
+
+public interface TechwatchModulePort {
+    Mono<Void> addAndSubscribePersonalFeed(PersonalFeed personalFeed);
+}

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/infra/adapters/TechwatchModuleAdapter.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/infra/adapters/TechwatchModuleAdapter.java
@@ -1,0 +1,34 @@
+package fr.ght1pc9kc.baywatch.security.infra.adapters;
+
+import fr.ght1pc9kc.baywatch.common.api.model.FeedMeta;
+import fr.ght1pc9kc.baywatch.security.domain.model.PersonalFeed;
+import fr.ght1pc9kc.baywatch.security.domain.ports.TechwatchModulePort;
+import fr.ght1pc9kc.baywatch.techwatch.api.FeedService;
+import fr.ght1pc9kc.baywatch.techwatch.api.model.WebFeed;
+import fr.ght1pc9kc.entity.api.Entity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class TechwatchModuleAdapter implements TechwatchModulePort {
+    private final FeedService feedService;
+
+    @Override
+    public Mono<Void> addAndSubscribePersonalFeed(PersonalFeed personalFeed) {
+        Entity<WebFeed> personalUserWebFeed = Entity.identify(WebFeed.builder()
+                        .name(personalFeed.name())
+                        .description(personalFeed.description())
+                        .icon(personalFeed.icon())
+                        .location(personalFeed.location())
+                        .build())
+                .meta(FeedMeta.visible, false)
+                .withId(personalFeed.id());
+
+        return feedService.addAndSubscribe(List.of(personalUserWebFeed))
+                .then();
+    }
+}

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/infra/adapters/TechwatchModuleAdapter.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/infra/adapters/TechwatchModuleAdapter.java
@@ -1,6 +1,8 @@
 package fr.ght1pc9kc.baywatch.security.infra.adapters;
 
+import fr.ght1pc9kc.baywatch.admin.api.FeedManagementService;
 import fr.ght1pc9kc.baywatch.common.api.model.FeedMeta;
+import fr.ght1pc9kc.baywatch.security.api.model.User;
 import fr.ght1pc9kc.baywatch.security.domain.model.PersonalFeed;
 import fr.ght1pc9kc.baywatch.security.domain.ports.TechwatchModulePort;
 import fr.ght1pc9kc.baywatch.techwatch.api.FeedService;
@@ -16,6 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TechwatchModuleAdapter implements TechwatchModulePort {
     private final FeedService feedService;
+    private final FeedManagementService feedManagementService;
 
     @Override
     public Mono<Void> addAndSubscribePersonalFeed(PersonalFeed personalFeed) {
@@ -30,5 +33,15 @@ public class TechwatchModuleAdapter implements TechwatchModulePort {
 
         return feedService.addAndSubscribe(List.of(personalUserWebFeed))
                 .then();
+    }
+
+    @Override
+    public Mono<Void> unsubscribePersonalFeed(Entity<User> user) {
+        return feedService.unsubscribe(List.of(user.id())).then();
+    }
+
+    @Override
+    public Mono<Void> deletePersonalFeed(Entity<User> user) {
+        return feedManagementService.delete(List.of(user.id()));
     }
 }

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/infra/adapters/UserServiceAdapter.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/security/infra/adapters/UserServiceAdapter.java
@@ -10,6 +10,7 @@ import fr.ght1pc9kc.baywatch.security.api.UserService;
 import fr.ght1pc9kc.baywatch.security.domain.UserServiceImpl;
 import fr.ght1pc9kc.baywatch.security.domain.ports.AuthorizationPersistencePort;
 import fr.ght1pc9kc.baywatch.security.domain.ports.NotificationPort;
+import fr.ght1pc9kc.baywatch.security.domain.ports.TechwatchModulePort;
 import fr.ght1pc9kc.baywatch.security.domain.ports.UserPersistencePort;
 import fr.ght1pc9kc.baywatch.security.infra.model.BaywatchUserDetails;
 import fr.ght1pc9kc.juery.api.Criteria;
@@ -44,11 +45,12 @@ public class UserServiceAdapter implements AuthorizationService, UserService, Re
     @Autowired
     public UserServiceAdapter(UserPersistencePort userPersistencePort,
                               AuthorizationPersistencePort authorizationRepository,
+                              TechwatchModulePort techwatchModulePort,
                               NotificationPort notificationPort,
                               AuthenticationFacade authFacade,
                               PasswordService passwordService) {
         this.delegate = new UserServiceImpl(
-                userPersistencePort, authorizationRepository, notificationPort, authFacade, passwordService,
+                userPersistencePort, authorizationRepository, techwatchModulePort, notificationPort, authFacade, passwordService,
                 Clock.systemUTC(), UlidFactory.newMonotonicInstance());
         this.delegateA = (UserServiceImpl) this.delegate;
     }

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/domain/FeedServiceImpl.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/domain/FeedServiceImpl.java
@@ -32,6 +32,7 @@ import static fr.ght1pc9kc.baywatch.common.api.DefaultMeta.NO_ONE;
 import static fr.ght1pc9kc.baywatch.common.api.exceptions.UnauthorizedException.AUTHENTICATION_NOT_FOUND;
 import static fr.ght1pc9kc.baywatch.common.api.model.EntitiesProperties.ID;
 import static fr.ght1pc9kc.baywatch.common.api.model.FeedMeta.createdBy;
+import static fr.ght1pc9kc.baywatch.common.api.model.FeedMeta.visible;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
@@ -224,7 +225,9 @@ public class FeedServiceImpl implements FeedService {
     private Mono<? extends Collection<Entity<WebFeed>>> completeFeedData(Collection<Entity<WebFeed>> feeds) {
         return Flux.fromIterable(feeds)
                 .parallel(4)
-                .flatMap(f -> scraperService.fetchFeedData(f.self().location()).map(a -> Tuples.of(f, a)))
+                .flatMap(f -> (f.meta(visible, Boolean.class).orElse(true))
+                        ? scraperService.fetchFeedData(f.self().location()).map(a -> Tuples.of(f, a))
+                        : Mono.just(Tuples.of(f, f.self())))
                 .sequential()
                 .map(t -> {
                     Entity<WebFeed> oldf = t.getT1();

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/persistence/FeedRepository.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/adapters/persistence/FeedRepository.java
@@ -356,6 +356,7 @@ public class FeedRepository implements FeedPersistencePort {
         select.addSelect(FEEDS.fields());
         select.addFrom(FEEDS);
         select.addConditions(conditions);
+        select.addConditions(FEEDS.FEED_VISIBLE.isTrue());
 
         if (qCtx.isScoped()) {
             if (filterProperties.contains(TAGS)) {

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/config/TechwatchMapper.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/config/TechwatchMapper.java
@@ -80,7 +80,9 @@ public interface TechwatchMapper {
         feed.meta(updated, Instant.class).map(DateUtils::toLocalDateTime)
                 .ifPresent(feedsRecord::setFeedLastWatch);
         feed.meta(ETag).ifPresent(feedsRecord::setFeedLastEtag);
-        feed.meta(visible, Boolean.class).ifPresent(feedsRecord::setFeedVisible);
+        feed.meta(visible, Boolean.class).ifPresentOrElse(
+                feedsRecord::setFeedVisible,
+                () -> feedsRecord.setFeedVisible(true));
         if (nonNull(feed.self().name())) {
             feedsRecord.setFeedName(feed.self().name());
         }

--- a/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/config/TechwatchMapper.java
+++ b/sandside/src/main/java/fr/ght1pc9kc/baywatch/techwatch/infra/config/TechwatchMapper.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import static fr.ght1pc9kc.baywatch.common.api.model.FeedMeta.ETag;
 import static fr.ght1pc9kc.baywatch.common.api.model.FeedMeta.createdBy;
 import static fr.ght1pc9kc.baywatch.common.api.model.FeedMeta.updated;
+import static fr.ght1pc9kc.baywatch.common.api.model.FeedMeta.visible;
 import static fr.ght1pc9kc.baywatch.dsl.tables.Feeds.FEEDS;
 import static fr.ght1pc9kc.baywatch.dsl.tables.FeedsUsers.FEEDS_USERS;
 import static java.util.Objects.nonNull;
@@ -79,6 +80,7 @@ public interface TechwatchMapper {
         feed.meta(updated, Instant.class).map(DateUtils::toLocalDateTime)
                 .ifPresent(feedsRecord::setFeedLastWatch);
         feed.meta(ETag).ifPresent(feedsRecord::setFeedLastEtag);
+        feed.meta(visible, Boolean.class).ifPresent(feedsRecord::setFeedVisible);
         if (nonNull(feed.self().name())) {
             feedsRecord.setFeedName(feed.self().name());
         }

--- a/sandside/src/main/resources/db/migration/V2_2_202507301707__add_users_personal_feed.sql
+++ b/sandside/src/main/resources/db/migration/V2_2_202507301707__add_users_personal_feed.sql
@@ -1,9 +1,18 @@
+alter table FEEDS add column FEED_VISIBLE boolean not null default true;
+
 insert into FEEDS
-select USERS.USER_ID,
+select USER_ID,
        USER_NAME,
        'https://localhost/' || USER_ID,
        null,
        'Personal Baywatch pocket for you',
        null,
-       'https://www.gravatar.com/avatar/' || USER_ID || '?s=96&d=retro'
+       'https://www.gravatar.com/avatar/' || USER_ID || '?s=96&d=retro',
+       false
 from USERS;
+
+insert into FEEDS_USERS
+select USER_ID,
+       USER_ID
+from USERS;
+

--- a/sandside/src/main/resources/db/migration/V2_2_202507301707__add_users_personal_feed.sql
+++ b/sandside/src/main/resources/db/migration/V2_2_202507301707__add_users_personal_feed.sql
@@ -1,0 +1,9 @@
+insert into FEEDS
+select USERS.USER_ID,
+       USER_NAME,
+       'https://localhost/' || USER_ID,
+       null,
+       'Personal Baywatch pocket for you',
+       null,
+       'https://www.gravatar.com/avatar/' || USER_ID || '?s=96&d=retro'
+from USERS;

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/security/domain/UserServiceImplTest.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/security/domain/UserServiceImplTest.java
@@ -13,8 +13,10 @@ import fr.ght1pc9kc.baywatch.security.api.model.Permission;
 import fr.ght1pc9kc.baywatch.security.api.model.Role;
 import fr.ght1pc9kc.baywatch.security.api.model.User;
 import fr.ght1pc9kc.baywatch.security.domain.exceptions.UnauthorizedOperation;
+import fr.ght1pc9kc.baywatch.security.domain.model.PersonalFeed;
 import fr.ght1pc9kc.baywatch.security.domain.ports.AuthorizationPersistencePort;
 import fr.ght1pc9kc.baywatch.security.domain.ports.NotificationPort;
+import fr.ght1pc9kc.baywatch.security.domain.ports.TechwatchModulePort;
 import fr.ght1pc9kc.baywatch.security.domain.ports.UserPersistencePort;
 import fr.ght1pc9kc.baywatch.tests.samples.UserSamples;
 import fr.ght1pc9kc.entity.api.Entity;
@@ -25,6 +27,10 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -41,15 +47,14 @@ import static fr.ght1pc9kc.baywatch.common.api.model.UserMeta.createdAt;
 import static fr.ght1pc9kc.baywatch.common.api.model.UserMeta.createdBy;
 import static fr.ght1pc9kc.baywatch.common.api.model.UserMeta.loginAt;
 import static fr.ght1pc9kc.baywatch.common.api.model.UserMeta.loginIP;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -58,14 +63,25 @@ class UserServiceImplTest {
     private final UserPersistencePort mockUserRepository = mock(UserPersistencePort.class);
     private final AuthorizationPersistencePort mockAuthorizationRepository = mock(AuthorizationPersistencePort.class);
     private final AuthenticationFacade mockAuthFacade = mock(AuthenticationFacade.class);
-    private final UlidFactory mockUlidFactory = spy(UlidFactory.newMonotonicInstance());
+    private final UlidFactory mockUlidFactory = mock(UlidFactory.class);
     private final NotificationPort mockNotificationPort = mock(NotificationPort.class);
+    private final TechwatchModulePort mockTechwatchModulePort = mock(TechwatchModulePort.class);
 
     private UserServiceImpl tested;
 
     @BeforeEach
+    @SuppressWarnings("unchecked")
     void setUp() {
+        when(mockUlidFactory.create()).thenReturn(Ulid.from("01EAWYQD0927XW36X4Z0000000"));
         when(mockAuthFacade.getConnectedUser()).thenReturn(Mono.just(UserSamples.YODA));
+        when(mockAuthFacade.withAuthentication(any())).thenAnswer(a -> {
+            Entity<User> user = (Entity<User>) a.getArgument(0, Entity.class);
+            Authentication authentication = new PreAuthenticatedAuthenticationToken(user, null,
+                    AuthorityUtils.createAuthorityList(user.self().roles().stream()
+                            .map(Permission::toString)
+                            .toArray(String[]::new)));
+            return ReactiveSecurityContextHolder.withAuthentication(authentication);
+        });
         doAnswer(answer -> Stream.of(UserSamples.LUKE, UserSamples.YODA, UserSamples.OBIWAN)
                 .filter(u -> u.id().equals(answer.getArgument(0, String.class)))
                 .findAny().map(Mono::just).orElseThrow()
@@ -88,8 +104,14 @@ class UserServiceImplTest {
         doAnswer(a -> a.getArgument(0).equals(a.getArgument(1))).when(mockPasswordService).matches(anyString(), anyString());
         doReturn(Mono.just(new PasswordEvaluation(true, 65d, "ok")))
                 .when(mockPasswordService).checkPasswordStrength(any(User.class));
-        tested = new UserServiceImpl(mockUserRepository, mockAuthorizationRepository, mockNotificationPort,
-                mockAuthFacade, mockPasswordService, Clock.fixed(CURRENT, ZoneOffset.UTC), mockUlidFactory);
+
+        when(mockTechwatchModulePort.addAndSubscribePersonalFeed(any())).thenReturn(Mono.empty().then());
+        when(mockTechwatchModulePort.unsubscribePersonalFeed(any())).thenReturn(Mono.empty().then());
+        when(mockTechwatchModulePort.deletePersonalFeed(any())).thenReturn(Mono.empty().then());
+
+        tested = new UserServiceImpl(mockUserRepository, mockAuthorizationRepository, mockTechwatchModulePort,
+                mockNotificationPort, mockAuthFacade, mockPasswordService,
+                Clock.fixed(CURRENT, ZoneOffset.UTC), mockUlidFactory);
     }
 
     @Test
@@ -128,14 +150,22 @@ class UserServiceImplTest {
         ArgumentCaptor<List<Entity<User>>> actuals = ArgumentCaptor.forClass(List.class);
         verify(mockUserRepository).persist(actuals.capture());
 
-        Entity<User> actual = actuals.getValue().getFirst();
-        assertAll(
-                () -> Assertions.assertThat(actual.id()).isNotBlank(),
-                () -> Assertions.assertThat(actual.meta(createdBy)).isPresent().contains(actual.id()),
-                () -> Assertions.assertThat(actual.meta(createdAt, Instant.class))
-                        .isPresent().contains(CURRENT),
-                () -> Assertions.assertThat(actual.self()).isEqualTo(UserSamples.OBIWAN.self())
-        );
+        SoftAssertions.assertSoftly(softly -> {
+            Entity<User> actual = actuals.getValue().getFirst();
+            softly.assertThat(actual.id()).isNotBlank();
+            softly.assertThat(actual.meta(createdBy)).isPresent().contains("US01EAWYQD0927XW36X4Z0000000");
+            softly.assertThat(actual.meta(createdAt, Instant.class)).isPresent().contains(CURRENT);
+            softly.assertThat(actual.self()).isEqualTo(UserSamples.OBIWAN.self());
+        });
+
+        ArgumentCaptor<PersonalFeed> personalFeedCaptor = ArgumentCaptor.forClass(PersonalFeed.class);
+        verify(mockTechwatchModulePort).addAndSubscribePersonalFeed(personalFeedCaptor.capture());
+        SoftAssertions.assertSoftly(softly -> {
+            PersonalFeed actual = personalFeedCaptor.getValue();
+            softly.assertThat(actual.id()).isEqualTo("US01EAWYQD0927XW36X4Z0000000");
+            softly.assertThat(actual.icon())
+                    .hasToString("https://www.gravatar.com/avatar/1a06a15b937d2a5ebeb93846cc83669b?s=96&d=retro");
+        });
     }
 
     @Test
@@ -159,13 +189,22 @@ class UserServiceImplTest {
         ArgumentCaptor<List<Entity<User>>> users = ArgumentCaptor.forClass(List.class);
         verify(mockUserRepository).persist(users.capture());
 
-        Entity<User> actual = users.getValue().getFirst();
-        assertAll(
-                () -> Assertions.assertThat(actual.id()).isNotBlank(),
-                () -> Assertions.assertThat(actual.meta(createdBy)).isPresent().contains(UserSamples.YODA.id()),
-                () -> Assertions.assertThat(actual.meta(createdAt, Instant.class)).isPresent().contains(CURRENT),
-                () -> Assertions.assertThat(actual.self()).isEqualTo(UserSamples.OBIWAN.self())
-        );
+        SoftAssertions.assertSoftly(softly -> {
+            Entity<User> actual = users.getValue().getFirst();
+            softly.assertThat(actual.id()).isNotBlank();
+            softly.assertThat(actual.meta(createdBy)).isPresent().contains(UserSamples.YODA.id());
+            softly.assertThat(actual.meta(createdAt, Instant.class)).isPresent().contains(CURRENT);
+            softly.assertThat(actual.self()).isEqualTo(UserSamples.OBIWAN.self());
+        });
+
+        ArgumentCaptor<PersonalFeed> personalFeedCaptor = ArgumentCaptor.forClass(PersonalFeed.class);
+        verify(mockTechwatchModulePort).addAndSubscribePersonalFeed(personalFeedCaptor.capture());
+        SoftAssertions.assertSoftly(softly -> {
+            PersonalFeed actual = personalFeedCaptor.getValue();
+            softly.assertThat(actual.id()).isEqualTo(UserSamples.OBIWAN.id());
+            softly.assertThat(actual.icon())
+                    .hasToString("https://www.gravatar.com/avatar/1a06a15b937d2a5ebeb93846cc83669b?s=96&d=retro");
+        });
     }
 
     @Test
@@ -265,6 +304,9 @@ class UserServiceImplTest {
         Assertions.assertThat(selected.getValue())
                 .isEqualTo(QueryContext.all(Criteria.property(EntitiesProperties.ID).in(UserSamples.OBIWAN.id())));
         Assertions.assertThat(deleted.getValue()).isEqualTo(List.of(UserSamples.OBIWAN.id()));
+
+        verify(mockTechwatchModulePort).unsubscribePersonalFeed(eq(UserSamples.OBIWAN));
+        verify(mockTechwatchModulePort).deletePersonalFeed(eq(UserSamples.OBIWAN));
     }
 
     @Test

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/security/domain/UserServiceImplTest.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/security/domain/UserServiceImplTest.java
@@ -50,7 +50,6 @@ import static fr.ght1pc9kc.baywatch.common.api.model.UserMeta.loginIP;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -305,8 +304,8 @@ class UserServiceImplTest {
                 .isEqualTo(QueryContext.all(Criteria.property(EntitiesProperties.ID).in(UserSamples.OBIWAN.id())));
         Assertions.assertThat(deleted.getValue()).isEqualTo(List.of(UserSamples.OBIWAN.id()));
 
-        verify(mockTechwatchModulePort).unsubscribePersonalFeed(eq(UserSamples.OBIWAN));
-        verify(mockTechwatchModulePort).deletePersonalFeed(eq(UserSamples.OBIWAN));
+        verify(mockTechwatchModulePort).unsubscribePersonalFeed(UserSamples.OBIWAN);
+        verify(mockTechwatchModulePort).deletePersonalFeed(UserSamples.OBIWAN);
     }
 
     @Test

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/security/infra/adapters/TechwatchModuleAdapterTest.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/security/infra/adapters/TechwatchModuleAdapterTest.java
@@ -1,0 +1,56 @@
+package fr.ght1pc9kc.baywatch.security.infra.adapters;
+
+import fr.ght1pc9kc.baywatch.admin.api.FeedManagementService;
+import fr.ght1pc9kc.baywatch.security.domain.model.PersonalFeed;
+import fr.ght1pc9kc.baywatch.techwatch.api.FeedService;
+import fr.ght1pc9kc.baywatch.tests.samples.UserSamples;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TechwatchModuleAdapterTest {
+
+    private TechwatchModuleAdapter tested;
+    private final FeedService mockFeedService = mock(FeedService.class);
+    private final FeedManagementService mockFeedManagementService = mock(FeedManagementService.class);
+
+    @BeforeEach
+    void setUp() {
+        when(mockFeedService.addAndSubscribe(anyCollection())).thenReturn(Flux.empty());
+        when(mockFeedService.unsubscribe(anyCollection())).thenReturn(Mono.empty());
+        when(mockFeedManagementService.delete(anyCollection())).thenReturn(Mono.empty());
+
+        tested = new TechwatchModuleAdapter(mockFeedService, mockFeedManagementService);
+    }
+
+    @Test
+    void should_delegate_subscribe() {
+        StepVerifier.create(tested.addAndSubscribePersonalFeed(PersonalFeed.of(UserSamples.OBIWAN)))
+                .verifyComplete();
+
+        verify(mockFeedService).addAndSubscribe(anyCollection());
+    }
+
+    @Test
+    void should_delegate_unsubscribe() {
+        StepVerifier.create(tested.unsubscribePersonalFeed(UserSamples.OBIWAN))
+                .verifyComplete();
+
+        verify(mockFeedService).unsubscribe(anyCollection());
+    }
+
+    @Test
+    void should_delegate_delete() {
+        StepVerifier.create(tested.deletePersonalFeed(UserSamples.OBIWAN))
+                .verifyComplete();
+
+        verify(mockFeedManagementService).delete(anyCollection());
+    }
+}

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/security/infra/persistence/UserRepositoryTest.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/security/infra/persistence/UserRepositoryTest.java
@@ -239,7 +239,7 @@ class UserRepositoryTest {
         Assertions.assertAll(
                 () -> assertThat(dsl.fetchCount(Users.USERS)).isEqualTo(2),
                 () -> assertThat(dsl.fetchCount(NEWS_USER_STATE)).isEqualTo(50),
-                () -> assertThat(dsl.fetchCount(FEEDS_USERS)).isEqualTo(6)
+                () -> assertThat(dsl.fetchCount(FEEDS_USERS)).isEqualTo(8)
         );
 
         tested.delete(List.of(UsersRecordSamples.OKENOBI.getUserId())).block();
@@ -247,7 +247,7 @@ class UserRepositoryTest {
         Assertions.assertAll(
                 () -> assertThat(dsl.fetchCount(Users.USERS)).isEqualTo(1),
                 () -> assertThat(dsl.fetchCount(NEWS_USER_STATE)).isEqualTo(25),
-                () -> assertThat(dsl.fetchCount(FEEDS_USERS)).isEqualTo(2)
+                () -> assertThat(dsl.fetchCount(FEEDS_USERS)).isEqualTo(3)
         );
     }
 

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/techwatch/domain/FeedServiceImplTest.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/techwatch/domain/FeedServiceImplTest.java
@@ -185,4 +185,94 @@ class FeedServiceImplTest {
                 .verifyError(IllegalArgumentException.class);
 
     }
+
+    @Test
+    void should_count_feeds_for_authenticated_user() {
+        when(mockAuthFacade.getConnectedUser()).thenReturn(Mono.just(UserSamples.OBIWAN));
+        StepVerifier.create(tested.count(PageRequest.all()))
+                .expectNext(42)
+                .verifyComplete();
+
+        verify(mockFeedRepository, times(1)).count(any(QueryContext.class));
+    }
+
+    @Test
+    void should_count_feeds_for_anonymous_user() {
+        when(mockAuthFacade.getConnectedUser()).thenReturn(Mono.empty());
+        StepVerifier.create(tested.count(PageRequest.all()))
+                .expectNext(42)
+                .verifyComplete();
+
+        verify(mockFeedRepository, times(1)).count(any(QueryContext.class));
+    }
+
+    @Test
+    void should_fail_to_count_feeds_if_unauthenticated_user() {
+        when(mockAuthFacade.getConnectedUser()).thenReturn(Mono.error(new UnauthenticatedUser("User must be authenticated")));
+
+        StepVerifier.create(tested.count(PageRequest.all()))
+                .expectNext(42)
+                .verifyComplete(); // Should handle error and fallback as anonymous
+
+        verify(mockFeedRepository, times(1)).count(any(QueryContext.class));
+    }
+
+    @Test
+    void should_add_and_subscribe_feeds() {
+        Entity<WebFeed> jediFeed = BAYWATCH_MAPPER.recordToFeed(FeedRecordSamples.JEDI);
+        when(mockAuthFacade.getConnectedUser()).thenReturn(Mono.just(UserSamples.OBIWAN));
+        when(mockFeedRepository.persist(anyCollection())).thenReturn(Flux.just(jediFeed));
+        when(mockFeedRepository.persistUserRelation(anyString(), anyCollection())).thenReturn(Flux.just(jediFeed));
+
+        StepVerifier.create(tested.addAndSubscribe(List.of(jediFeed)))
+                .expectNextCount(1)
+                .verifyComplete();
+
+        verify(mockFeedRepository).persist(anyCollection());
+        verify(mockFeedRepository).persistUserRelation(anyString(), anyCollection());
+    }
+
+    @Test
+    void should_unsubscribe_feeds() {
+        when(mockAuthFacade.getConnectedUser()).thenReturn(Mono.just(UserSamples.OBIWAN));
+        when(mockFeedRepository.deleteUserRelations(anyString(), anyCollection())).thenReturn(Mono.empty());
+        when(mockFeedRepository.deleteFeedProperties(anyString(), anyCollection())).thenReturn(Mono.empty());
+
+        StepVerifier.create(tested.unsubscribe(List.of("42")))
+                .expectNext(1)
+                .verifyComplete();
+
+        verify(mockFeedRepository).deleteUserRelations(anyString(), anyCollection());
+        verify(mockFeedRepository).deleteFeedProperties(anyString(), anyCollection());
+    }
+
+    @Test
+    void should_fail_to_unsubscribe_if_unauthenticated() {
+        when(mockAuthFacade.getConnectedUser()).thenReturn(Mono.empty());
+
+        StepVerifier.create(tested.unsubscribe(List.of("42")))
+                .verifyError(UnauthenticatedUser.class);
+
+        verify(mockFeedRepository, times(0)).deleteUserRelations(anyString(), anyCollection());
+        verify(mockFeedRepository, times(0)).deleteFeedProperties(anyString(), anyCollection());
+    }
+
+    @Test
+    void should_override_feed_properties_when_none_found() {
+        when(mockAuthFacade.getConnectedUser()).thenReturn(Mono.just(UserSamples.OBIWAN));
+        Entity<WebFeed> jediFeed = BAYWATCH_MAPPER.recordToFeed(FeedRecordSamples.JEDI);
+        Entity<WebFeed> overrideJediFeed = jediFeed.convert(original -> original.toBuilder()
+                .name(original.name() + "-overridden")
+                .description(original.description() + "-overridden")
+                .icon(URI.create("http://www.jedi.light/overridden.png"))
+                .tags(List.of("override", "jedi"))
+                .build());
+
+        StepVerifier.create(tested.addAndSubscribe(List.of(overrideJediFeed)))
+                .expectNextCount(1)
+                .verifyComplete();
+
+        verify(mockFeedRepository).setFeedProperties(eq(UsersRecordSamples.OKENOBI.getUserId()), anyCollection());
+    }
+
 }

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/techwatch/infra/persistence/FeedRepositoryTest.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/techwatch/infra/persistence/FeedRepositoryTest.java
@@ -73,7 +73,6 @@ class FeedRepositoryTest {
             .build();
 
     @RegisterExtension
-    @SuppressWarnings("unused")
     static ChainedExtension chain = ChainedExtension.outer(wDs)
             .append(wDslContext)
             .append(wSamples)
@@ -107,14 +106,18 @@ class FeedRepositoryTest {
     void should_list_all_feeds(WithSampleDataLoaded.Tracker dbTracker) {
         dbTracker.skipNextSampleLoad();
         List<Entity<WebFeed>> actuals = tested.list().collectList().block();
-        assertThat(actuals).isNotEmpty();
+        assertThat(actuals).isNotEmpty()
+                .describedAs("Must contain only visible feeds")
+                .hasSize((int) FeedRecordSamples.SAMPLE.records().stream()
+                        .filter(FeedsRecord::getFeedVisible).count());
     }
 
     @Test
     void should_manage_backpressure(WithSampleDataLoaded.Tracker dbTracker) {
         dbTracker.skipNextSampleLoad();
         List<Entity<WebFeed>> actuals = tested.list().limitRate(2).collectList().block();
-        assertThat(actuals).hasSize(FeedRecordSamples.SAMPLE.records().size());
+        assertThat(actuals).hasSize((int) FeedRecordSamples.SAMPLE.records().stream()
+                .filter(FeedsRecord::getFeedVisible).count());
     }
 
     @Test
@@ -269,8 +272,8 @@ class FeedRepositoryTest {
     void should_list_orphan_feed(WithSampleDataLoaded.Tracker tracker) {
         tracker.skipNextSampleLoad();
         List<Entity<WebFeed>> actuals = tested.list(QueryContext.all(Criteria.property(COUNT).eq(0))).collectList().block();
-        assertThat(actuals).extracting(Entity::id).containsExactly(
-                FeedRecordSamples.FEEDS_RECORDS.getLast().getFeedId());
+        assertThat(actuals).extracting(Entity::id).containsExactly(FeedRecordSamples.FEEDS_RECORDS.stream()
+                .filter(FeedsRecord::getFeedVisible).toList().getLast().getFeedId());
     }
 
     @Test

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/techwatch/infra/persistence/FeedRepositoryTest.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/techwatch/infra/persistence/FeedRepositoryTest.java
@@ -129,7 +129,7 @@ class FeedRepositoryTest {
                 .meta(updated, Instant.EPOCH)
                 .withId(reference);
 
-        StepVerifier.create(tested.persist(Collections.singleton(expected)))
+        StepVerifier.create(tested.persist(List.of(expected)))
                 .assertNext(actual -> assertThat(actual).isEqualTo(expected))
                 .verifyComplete();
 

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/tests/samples/infra/FeedRecordSamples.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/tests/samples/infra/FeedRecordSamples.java
@@ -23,7 +23,8 @@ public class FeedRecordSamples implements RelationalDataSet<FeedsRecord> {
             .setFeedName("Jedi")
             .setFeedUrl(JEDI_BASE_URI.toString())
             .setFeedDescription("Feed description")
-            .setFeedLastWatch(LocalDateTime.parse("2020-12-11T15:12:42"));
+            .setFeedLastWatch(LocalDateTime.parse("2020-12-11T15:12:42"))
+            .setFeedVisible(true);
 
     public static final List<FeedsRecord> FEEDS_RECORDS = List.of(
             JEDI,

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/tests/samples/infra/FeedRecordSamples.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/tests/samples/infra/FeedRecordSamples.java
@@ -3,6 +3,7 @@ package fr.ght1pc9kc.baywatch.tests.samples.infra;
 import fr.ght1pc9kc.baywatch.common.domain.Hasher;
 import fr.ght1pc9kc.baywatch.dsl.tables.records.FeedsRecord;
 import fr.ght1pc9kc.baywatch.dsl.tables.records.FeedsUsersRecord;
+import fr.ght1pc9kc.baywatch.tests.samples.UserSamples;
 import fr.ght1pc9kc.testy.jooq.model.RelationalDataSet;
 
 import java.net.URI;
@@ -25,6 +26,18 @@ public class FeedRecordSamples implements RelationalDataSet<FeedsRecord> {
             .setFeedDescription("Feed description")
             .setFeedLastWatch(LocalDateTime.parse("2020-12-11T15:12:42"))
             .setFeedVisible(true);
+    public static final FeedsRecord OBIWAN_PERSONAL = FEEDS.newRecord()
+            .setFeedId(UserSamples.OBIWAN.id())
+            .setFeedName(UserSamples.OBIWAN.self().name())
+            .setFeedUrl("https://localhost/" + UserSamples.OBIWAN.id())
+            .setFeedDescription("Obiwan personal Feed")
+            .setFeedVisible(false);
+    public static final FeedsRecord LUKE_PERSONAL = FEEDS.newRecord()
+            .setFeedId(UserSamples.LUKE.id())
+            .setFeedName(UserSamples.LUKE.self().name())
+            .setFeedUrl("https://localhost/" + UserSamples.LUKE.id())
+            .setFeedDescription("Luke personal Feed")
+            .setFeedVisible(false);
 
     public static final List<FeedsRecord> FEEDS_RECORDS = List.of(
             JEDI,
@@ -32,7 +45,8 @@ public class FeedRecordSamples implements RelationalDataSet<FeedsRecord> {
             JEDI.copy().setFeedId(Hasher.identify(JEDI_BASE_URI.resolve("02"))).setFeedUrl(JEDI.getFeedUrl() + "02"),
             JEDI.copy().setFeedId(Hasher.identify(JEDI_BASE_URI.resolve("03"))).setFeedUrl(JEDI.getFeedUrl() + "03"),
             JEDI.copy().setFeedId(Hasher.identify(JEDI_BASE_URI.resolve("04"))).setFeedUrl(JEDI.getFeedUrl() + "04"),
-            JEDI.copy().setFeedId(Hasher.identify(JEDI_BASE_URI.resolve("05"))).setFeedUrl(JEDI.getFeedUrl() + "05")
+            JEDI.copy().setFeedId(Hasher.identify(JEDI_BASE_URI.resolve("05"))).setFeedUrl(JEDI.getFeedUrl() + "05"),
+            OBIWAN_PERSONAL, LUKE_PERSONAL
     );
 
     @Override

--- a/sandside/src/test/java/fr/ght1pc9kc/baywatch/tests/samples/infra/FeedsUsersRecordSample.java
+++ b/sandside/src/test/java/fr/ght1pc9kc/baywatch/tests/samples/infra/FeedsUsersRecordSample.java
@@ -5,9 +5,8 @@ import fr.ght1pc9kc.baywatch.dsl.tables.records.FeedsUsersRecord;
 import fr.ght1pc9kc.baywatch.dsl.tables.records.UsersRecord;
 import fr.ght1pc9kc.testy.jooq.model.RelationalDataSet;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import static fr.ght1pc9kc.baywatch.dsl.tables.FeedsUsers.FEEDS_USERS;
 
@@ -17,19 +16,36 @@ public class FeedsUsersRecordSample implements RelationalDataSet<FeedsUsersRecor
     public static final List<FeedsUsersRecord> FEEDS_USERS_RECORDS;
 
     static {
-        // -1 allow to keep one orphan feed for tests
-        FEEDS_USERS_RECORDS = Stream.concat(IntStream.range(0, FeedRecordSamples.FEEDS_RECORDS.size() - 1)
-                .mapToObj(f -> {
-                    FeedsRecord feed = FeedRecordSamples.FEEDS_RECORDS.get(f);
-                    List<UsersRecord> users = UsersRecordSamples.SAMPLE.records();
-                    return FEEDS_USERS.newRecord()
-                            .setFeusFeedId(feed.getFeedId())
-                            .setFeusUserId(users.get(f % users.size()).getUserId());
-                }), Stream.of( // Link the first FEED to Obiwan AND Luke
+        ArrayList<FeedsUsersRecord> records = new ArrayList<>(FeedRecordSamples.FEEDS_RECORDS.size());
+        int f = 0;
+        for (FeedsRecord feedsRecord : FeedRecordSamples.FEEDS_RECORDS) {
+            if (!feedsRecord.getFeedVisible()) {
+                continue;
+            }
+            List<UsersRecord> users = UsersRecordSamples.SAMPLE.records();
+            records.add(FEEDS_USERS.newRecord()
+                    .setFeusFeedId(feedsRecord.getFeedId())
+                    .setFeusUserId(users.get(f % users.size()).getUserId()));
+            ++f;
+        }
+        // allow keeping one orphan feed for tests
+        records.removeLast();
+
+        records.addAll(List.of(
+                // Link the first FEED to Obiwan AND Luke
                 FEEDS_USERS.newRecord()
                         .setFeusFeedId(FeedRecordSamples.FEEDS_RECORDS.get(1).getFeedId())
-                        .setFeusUserId(UsersRecordSamples.SAMPLE.records().get(0).getUserId())
-        )).toList();
+                        .setFeusUserId(UsersRecordSamples.SAMPLE.records().getFirst().getUserId()),
+                // Link the personal feeds
+                FEEDS_USERS.newRecord()
+                        .setFeusFeedId(FeedRecordSamples.OBIWAN_PERSONAL.getFeedId())
+                        .setFeusUserId(FeedRecordSamples.OBIWAN_PERSONAL.getFeedId()),
+                FEEDS_USERS.newRecord()
+                        .setFeusFeedId(FeedRecordSamples.LUKE_PERSONAL.getFeedId())
+                        .setFeusUserId(FeedRecordSamples.LUKE_PERSONAL.getFeedId())
+        ));
+
+        FEEDS_USERS_RECORDS = List.copyOf(records);
     }
 
     @Override

--- a/seaside/src/layout/components/AddSingleNewsAction.vue
+++ b/seaside/src/layout/components/AddSingleNewsAction.vue
@@ -1,18 +1,15 @@
 <template>
-  <label class="text-right relative w-full" @click.stop>
-    <button class="absolute -right-2 top-1/2 -mt-6 opacity-60 btn btn-circle btn-link text-secondary"
+  <label class="input w-full" @click.stop>
+    <span class="label">URL</span>
+    <input ref="linkInput" v-model="link" :class="{'input-error': hasError}"
+           placeholder="Paste url here" type="text"
+           @input="hasError = false"
+           @keyup.esc="$emit('close')"
+           @keyup.enter="importNewsFromLink"/>
+    <button class="label btn btn-link text-secondary"
             @click="importNewsFromLink">
-      <svg class="w-6 h-6 rotate-90" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-        <path
-            d="M10.894 2.553a1 1 0 00-1.788 0l-7 14a1 1 0 001.169 1.409l5-1.429A1 1 0 009 15.571V11a1 1 0 112
-            0v4.571a1 1 0 00.725.962l5 1.428a1 1 0 001.17-1.408l-7-14z"></path>
-      </svg>
+      <PlusCircleIcon class="h-6 w-6"/>
     </button>
-    <input ref="linkInput" v-model="link" :class="{'input-error': hasError}" class="input input-sm input-bordered w-full pr-8"
-           placeholder="Paste the news link"
-           type="text"
-           @input="hasError = false" @keyup.esc="$emit('close')" @keyup.enter="importNewsFromLink"
-    />
   </label>
 </template>
 
@@ -22,11 +19,13 @@ import { scraperImportStandaloneNews } from '@/layout/services/ScraperService';
 import notificationService from '@/services/notification/NotificationService';
 import { NotificationCode } from '@/services/notification/NotificationCode.enum';
 import { Severity } from '@/services/notification/Severity.enum';
+import { PlusCircleIcon } from '@heroicons/vue/24/outline';
 
 @Component({
   name: 'AddSingleNewsAction',
   emits: ['close'],
   props: ['isTransitioning'],
+  components: { PlusCircleIcon },
 })
 export default class AddSingleNewsAction extends Vue {
   @Prop() private isTransitioning!: boolean;

--- a/seaside/src/layout/components/AddSingleNewsAction.vue
+++ b/seaside/src/layout/components/AddSingleNewsAction.vue
@@ -1,27 +1,27 @@
 <template>
   <label class="text-right relative w-full" @click.stop>
-    <button @click="importNewsFromLink"
-            class="absolute -right-2 top-1/2 -mt-6 opacity-60 btn btn-circle btn-link text-secondary">
+    <button class="absolute -right-2 top-1/2 -mt-6 opacity-60 btn btn-circle btn-link text-secondary"
+            @click="importNewsFromLink">
       <svg class="w-6 h-6 rotate-90" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
         <path
             d="M10.894 2.553a1 1 0 00-1.788 0l-7 14a1 1 0 001.169 1.409l5-1.429A1 1 0 009 15.571V11a1 1 0 112
             0v4.571a1 1 0 00.725.962l5 1.428a1 1 0 001.17-1.408l-7-14z"></path>
       </svg>
     </button>
-    <input ref="linkInput" v-model="link" type="text" placeholder="Paste the news link"
-           class="input input-sm input-bordered w-full pr-8"
-           :class="{'input-error': hasError}"
+    <input ref="linkInput" v-model="link" :class="{'input-error': hasError}" class="input input-sm input-bordered w-full pr-8"
+           placeholder="Paste the news link"
+           type="text"
            @input="hasError = false" @keyup.esc="$emit('close')" @keyup.enter="importNewsFromLink"
     />
   </label>
 </template>
 
 <script lang="ts">
-import {Component, Prop, Vue, Watch} from "vue-facing-decorator";
-import scraperService from '@/layout/services/ScraperService';
-import notificationService from "@/services/notification/NotificationService";
-import {NotificationCode} from "@/services/notification/NotificationCode.enum";
-import {Severity} from "@/services/notification/Severity.enum";
+import { Component, Prop, Vue, Watch } from 'vue-facing-decorator';
+import { scraperImportStandaloneNews } from '@/layout/services/ScraperService';
+import notificationService from '@/services/notification/NotificationService';
+import { NotificationCode } from '@/services/notification/NotificationCode.enum';
+import { Severity } from '@/services/notification/Severity.enum';
 
 @Component({
   name: 'AddSingleNewsAction',
@@ -31,7 +31,7 @@ import {Severity} from "@/services/notification/Severity.enum";
 export default class AddSingleNewsAction extends Vue {
   @Prop() private isTransitioning!: boolean;
 
-  private link: string = "";
+  private link: string = '';
   private hasError: boolean = false;
 
   @Watch('isTransitioning')
@@ -43,10 +43,10 @@ export default class AddSingleNewsAction extends Vue {
 
   private importNewsFromLink(): void {
     this.$emit('close');
-    scraperService.importStandaloneNews(this.link).subscribe({
-      next: () => console.debug("Scraping request send successfully."),
+    scraperImportStandaloneNews(this.link).subscribe({
+      next: () => console.debug('Scraping request send successfully.'),
       error: err => notificationService.pushNotification({
-        code: NotificationCode.ERROR, message: `${err.message}`, severity: Severity.error
+        code: NotificationCode.ERROR, message: `${err.message}`, severity: Severity.error,
       }),
     });
   }

--- a/seaside/src/layout/services/ScraperService.ts
+++ b/seaside/src/layout/services/ScraperService.ts
@@ -3,24 +3,20 @@ import { map, take } from 'rxjs/operators';
 import { send } from '@/common/services/GraphQLClient';
 import { URL_PATTERN } from '@/common/services/RegexPattern';
 
-export class ScraperService {
-    private static readonly SCRAP_SINGLE_NEWS_REQUEST = `#graphql
-    mutation ScrapSingleNews($newsLink: URI!) {
-        scrapSimpleNews(uri: $newsLink)
-    }`;
+const SCRAP_SINGLE_NEWS_REQUEST = `#graphql
+mutation ScrapSingleNews($newsLink: URI!) {
+    scrapSimpleNews(uri: $newsLink)
+}`;
 
-    importStandaloneNews(link?: string): Observable<void> {
-        if (link === undefined) {
-            return throwError(() => new Error('Link is mandatory !'));
-        } else if (!URL_PATTERN.test(link)) {
-            return throwError(() => new Error('Argument link must be a valid URL !'));
-        }
-
-        return send(ScraperService.SCRAP_SINGLE_NEWS_REQUEST, { newsLink: link }).pipe(
-            take(1),
-            map(() => undefined),
-        );
+export function scraperImportStandaloneNews(link?: string): Observable<void> {
+    if (link === undefined) {
+        return throwError(() => new Error('Link is mandatory !'));
+    } else if (!URL_PATTERN.test(link)) {
+        return throwError(() => new Error('Argument link must be a valid URL !'));
     }
-}
 
-export default new ScraperService();
+    return send(SCRAP_SINGLE_NEWS_REQUEST, { newsLink: link }).pipe(
+        take(1),
+        map(() => undefined),
+    );
+}

--- a/seaside/tests/unit/layout/components/AddSingleNewsAction.test.ts
+++ b/seaside/tests/unit/layout/components/AddSingleNewsAction.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { of } from 'rxjs';
+import AddSingleNewsAction from '@/layout/components/AddSingleNewsAction.vue';
+
+// avoid store update console logs
+vi.hoisted(() => process.env.NODE_ENV = 'production');
+
+vi.mock('@/security/services/UserSettingsService', () => {
+    return {
+        userSettingsGet: vi.fn().mockImplementation(() => of({})),
+    };
+});
+
+describe('AddSingleNewsAction', () => {
+    test('renders component', () => {
+        const wrapper = mount(AddSingleNewsAction, {});
+        expect(wrapper.find('input').exists()).toBe(true);
+        expect(wrapper.find('button').exists()).toBe(true);
+    });
+});


### PR DESCRIPTION
Fixes the issue of single news items not displaying. When a single news item is added, it does not appear anywhere.

This is because solitary news items are implicitly linked to a virtual news feed with the same ID as the user to whom it belongs. However, since this feed does not exist in the feed table, adding the news item breaks the foreign constraint and the news item is then not linked to any feed and therefore does not appear anywhere.
